### PR TITLE
Support fixed channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ light:
 
 ### channel_setup
 
-A string to customize the channel layout of your light.
+A string or list to customize the channel layout of your light. If a list is provided, fixed numeric values may be included.
 
 #### Definition
 


### PR DESCRIPTION
I have a light that requires some fixed values interspersed with the brightness/rgb/etc. This change allows me to do this for example:
```
              channel_setup: 
                - d
                - t
                - W
                - R
                - 128
                - 255
                - G
                - B
```