### PR TITLE
robust string decoding with fallback

### DIFF
--- a/custom_components/artnet_led/client/__init__.py
+++ b/custom_components/artnet_led/client/__init__.py
@@ -491,7 +491,7 @@ class ArtBase:
                 log.debug(f"decoded as {encoding}: {sanitized_str}")
                 return sanitized_str
             except UnicodeDecodeError as e:
-                log.warning(f"failed ({e.reason} to decode as {encoding}: {bytes(byte_str).hex()}")
+                log.warning(f"failed ({e.reason}) to decode as {encoding}: {bytes(byte_str).hex()}")
 
     @staticmethod
     def peek_opcode(packet: bytearray) -> OpCode | None:

--- a/custom_components/artnet_led/client/__init__.py
+++ b/custom_components/artnet_led/client/__init__.py
@@ -3,8 +3,6 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-import unicodedata
-from lib2to3.pgen2.tokenize import group
 from typing import Optional
 
 CLIENT_VERSION = 1

--- a/custom_components/artnet_led/client/__init__.py
+++ b/custom_components/artnet_led/client/__init__.py
@@ -375,7 +375,7 @@ class TimeCodeType(Enum):
 
 
 class ArtBase:
-    __ENCODINGS__ = ['iso-8859-1', 'utf8']
+    __ENCODINGS__ = ['utf8', 'iso-8859-1']
 
     def __init__(self, opcode: OpCode) -> None:
         super().__init__()

--- a/custom_components/artnet_led/client/__init__.py
+++ b/custom_components/artnet_led/client/__init__.py
@@ -375,7 +375,7 @@ class TimeCodeType(Enum):
 
 
 class ArtBase:
-    __ENCODINGS__ = ['ascii', 'utf8']
+    __ENCODINGS__ = ['iso-8859-1', 'utf8']
 
     def __init__(self, opcode: OpCode) -> None:
         super().__init__()


### PR DESCRIPTION
This pull request adds a more robust string decoding for the artnet controller mode and resolves issue #70 

if the string cannot encoded as ascii, the new decoder tries to decode it as utf8 with a conversion to ascii. if the string is not decodeable, the hex representation of the string is returned as result.

To simply debugging for devices, a warning message will be printed if the decoding failes:

`WARNING (MainThread) [custom_components.artnet_led.client] failed to decode as ascii: 4e:65:74:57:6f:72:6b:20:4e:6f:64:65:20:32:28:34:32:3a:34:43:3a:38:34:3a:36:36:3a:45:45:3a:46:38:29:00:2e:00:70:8e:b0:02:01:00:23:00:42:6f:6f:74:20:4d:6f:64:65:3a:20:42:6f:6f:74:65:64:20:66:00`