### PR TITLE
Throttle send_universe_data to respect max_fps frame rate

### DIFF
--- a/custom_components/dmx/__init__.py
+++ b/custom_components/dmx/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.components.light import ATTR_TRANSITION
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import IntegrationError
-from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.typing import ConfigType
 
 from custom_components.dmx.const import CONF_FIXTURE_ENTITIES, DOMAIN
@@ -74,7 +73,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if DOMAIN not in config:
         return True
 
-    discovery_flow.async_create_flow(hass, DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config)
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config)
+    )
 
     return True
 

--- a/custom_components/dmx/animation/engine.py
+++ b/custom_components/dmx/animation/engine.py
@@ -129,7 +129,7 @@ class DmxAnimationEngine:
 
         # Send DMX updates to universe (non-blocking)
         if dmx_updates:
-            self.hass.create_task(self.universe.update_multiple_values(dmx_updates))
+            self.hass.async_create_task(self.universe.update_multiple_values(dmx_updates))
         else:
             _LOGGER.debug(f"No DMX updates generated from frame values: {frame_values}")
 

--- a/custom_components/dmx/entity/light/light_controller.py
+++ b/custom_components/dmx/entity/light/light_controller.py
@@ -75,18 +75,20 @@ class LightController:
         current_values = {}
         for channel_type in updates:
             current_entity_value = 0
-            dmx_values = []
             for mapping in self.channel_mappings:
                 if mapping.channel_type == channel_type:
-                    # Get all DMX values for this channel (handles multi-byte channels properly)
-                    dmx_values = [self.universe.get_channel_value(idx) for idx in mapping.dmx_indexes]
-
-                    # Convert DMX values to entity value using the dynamic entity
-                    capabilities = mapping.channel.capabilities
-                    first_capability = capabilities[0] if isinstance(capabilities, list) else capabilities
-                    [dynamic_entity] = first_capability.dynamic_entities
-                    normalized_value = dynamic_entity.from_dmx_fine(dmx_values)
-                    current_entity_value = int(dynamic_entity.unnormalize(normalized_value))
+                    if all(self.universe.is_channel_set(idx) for idx in mapping.dmx_indexes):
+                        # DMX values have been written; use them (handles mid-animation restarts)
+                        dmx_values = [self.universe.get_channel_value(idx) for idx in mapping.dmx_indexes]
+                        capabilities = mapping.channel.capabilities
+                        first_capability = capabilities[0] if isinstance(capabilities, list) else capabilities
+                        [dynamic_entity] = first_capability.dynamic_entities
+                        normalized_value = dynamic_entity.from_dmx_fine(dmx_values)
+                        current_entity_value = int(dynamic_entity.unnormalize(normalized_value))
+                    else:
+                        # Channel never written (e.g. after HA restart before first DMX send);
+                        # fall back to LightState which was restored from last_state
+                        current_entity_value = self.state.get_channel_entity_value(channel_type)
                     break
 
             current_values[channel_type] = int(current_entity_value)
@@ -201,3 +203,4 @@ class LightController:
     def _on_animation_complete(self) -> None:
         """Called when an animation completes naturally"""
         self._current_animation_id = None
+        self.state._preserve_last_values = False

--- a/custom_components/dmx/entity/light/light_entity.py
+++ b/custom_components/dmx/entity/light/light_entity.py
@@ -166,8 +166,9 @@ class DmxLightEntity(LightEntity, RestoreEntity):
 
         if "rgb_color" in attrs:
             rgb = attrs["rgb_color"]
-            self._state.rgb = rgb
-            self._state.last_rgb = rgb
+            if rgb is not None:
+                self._state.rgb = rgb
+                self._state.last_rgb = rgb
 
         if "color_temp_kelvin" in attrs:
             color_temp_kelvin = attrs["color_temp_kelvin"]

--- a/custom_components/dmx/entity/light/light_state.py
+++ b/custom_components/dmx/entity/light/light_state.py
@@ -79,7 +79,7 @@ class LightState:
             log.warning(f"RGB component update called for non-RGB color mode {self.color_mode}")
             return
 
-        new_rgb = list(self.rgb or (0, 0, 0))
+        new_rgb = list(self.rgb)
         new_rgb[component_index] = value
         self._update_rgb_based_on_color_mode(*new_rgb)
 
@@ -117,14 +117,11 @@ class LightState:
         if self.color_mode == ColorMode.COLOR_TEMP and self.has_cw_ww():
             self.is_on = self.cold_white > 0 or self.warm_white > 0
         elif self.color_mode == ColorMode.RGBWW:
-            rgb = self.rgb or (0, 0, 0)
-            self.is_on = any(v > 0 for v in (*rgb, self.cold_white, self.warm_white))
+            self.is_on = any(v > 0 for v in (*self.rgb, self.cold_white, self.warm_white))
         elif self.color_mode == ColorMode.RGBW:
-            rgb = self.rgb or (0, 0, 0)
-            self.is_on = any(v > 0 for v in (*rgb, self.warm_white))
+            self.is_on = any(v > 0 for v in (*self.rgb, self.warm_white))
         elif self.color_mode == ColorMode.RGB:
-            rgb = self.rgb or (0, 0, 0)
-            self.is_on = any(v > 0 for v in rgb)
+            self.is_on = any(v > 0 for v in self.rgb)
         elif self.has_channel(ChannelType.COLD_WHITE):
             self.is_on = self.cold_white > 0
         elif self.has_channel(ChannelType.WARM_WHITE):
@@ -294,7 +291,7 @@ class LightState:
     def _update_brightness_from_channels(self) -> None:
         values: list[int] = []
 
-        if self.has_rgb() and self.rgb is not None:
+        if self.has_rgb():
             values.extend(self.rgb)
 
         if self.has_channel(ChannelType.COLD_WHITE):
@@ -329,20 +326,16 @@ class LightState:
 
     @property
     def rgbw_color(self) -> tuple[int, int, int, int]:
-        rgb = self.rgb or (0, 0, 0)
-        return (*rgb, self.warm_white)
+        return (*self.rgb, self.warm_white)
 
     @property
     def rgbww_color(self) -> tuple[int, int, int, int, int]:
-        rgb = self.rgb or (0, 0, 0)
-        return (*rgb, self.cold_white, self.warm_white)
+        return (*self.rgb, self.cold_white, self.warm_white)
 
     @property
     def last_rgbw_color(self) -> tuple[int, int, int, int]:
-        last_rgb = self.last_rgb or (0, 0, 0)
-        return (*last_rgb, self.last_cold_white)
+        return (*self.last_rgb, self.last_cold_white)
 
     @property
     def last_rgbww_color(self) -> tuple[int, int, int, int, int]:
-        last_rgb = self.last_rgb or (0, 0, 0)
-        return (*last_rgb, self.last_cold_white, self.last_warm_white)
+        return (*self.last_rgb, self.last_cold_white, self.last_warm_white)

--- a/custom_components/dmx/entity/light/light_state.py
+++ b/custom_components/dmx/entity/light/light_state.py
@@ -165,6 +165,24 @@ class LightState:
 
         return updates
 
+    def get_channel_entity_value(self, channel_type: ChannelType) -> int:
+        """Return the current entity-space value for a channel type from the light state."""
+        if channel_type == ChannelType.DIMMER:
+            return self.brightness
+        if channel_type == ChannelType.RED:
+            return self.rgb[0]
+        if channel_type == ChannelType.GREEN:
+            return self.rgb[1]
+        if channel_type == ChannelType.BLUE:
+            return self.rgb[2]
+        if channel_type == ChannelType.COLD_WHITE:
+            return self.cold_white
+        if channel_type == ChannelType.WARM_WHITE:
+            return self.warm_white
+        if channel_type == ChannelType.COLOR_TEMPERATURE:
+            return round(self.color_temp_dmx)
+        return 0
+
     def get_dmx_updates(self, values: dict[ChannelType, int | float]) -> dict[int, int]:
         updates = {}
         for channel_type, val in values.items():

--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -25,11 +25,13 @@ class DmxUniverse:
         self.sacn_server = sacn_server
         self.sacn_universe = sacn_universe
         self.use_partial_universe = use_partial_universe
+        self._hass = hass
 
         self._channel_values: dict[int, int] = {}
         self._constant_values: dict[int, int] = {}
         self._channel_callbacks: dict[int, list[Callable[[str | None], None]]] = {}
         self._output_enabled: bool = True
+        self._send_timer: asyncio.TimerHandle | None = None
         self.animation_engine: DmxAnimationEngine | None = None
 
         if hass:
@@ -105,7 +107,21 @@ class DmxUniverse:
             await self._call_callback(callback, source)
 
         if send_update:
+            self._schedule_send()
+
+    def _schedule_send(self, delay: float = 0.05) -> None:
+        """Debounce send_universe_data: wait for `delay` seconds of quiet before sending."""
+        if self._send_timer is not None:
+            self._send_timer.cancel()
+
+        if self._hass:
+            self._send_timer = self._hass.loop.call_later(delay, self._do_send)
+        else:
             self.send_universe_data()
+
+    def _do_send(self) -> None:
+        self._send_timer = None
+        self.send_universe_data()
 
     @staticmethod
     async def _call_callback(callback: Callable[[str | None], None], source: str | None = None) -> None:

--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -32,6 +32,8 @@ class DmxUniverse:
         self._channel_callbacks: dict[int, list[Callable[[str | None], None]]] = {}
         self._output_enabled: bool = True
         self._send_timer: asyncio.TimerHandle | None = None
+        self._last_send_time: float = 0.0
+        self._frame_interval: float = 1.0 / max_fps
         self.animation_engine: DmxAnimationEngine | None = None
 
         if hass:
@@ -109,18 +111,34 @@ class DmxUniverse:
         if send_update:
             self._schedule_send()
 
-    def _schedule_send(self, delay: float = 0.05) -> None:
-        """Debounce send_universe_data: wait for `delay` seconds of quiet before sending."""
-        if self._send_timer is not None:
-            self._send_timer.cancel()
+    def _schedule_send(self) -> None:
+        """Throttle send_universe_data to at most once per frame interval.
 
-        if self._hass:
-            self._send_timer = self._hass.loop.call_later(delay, self._do_send)
-        else:
-            self.send_universe_data()
+        Sends immediately if enough time has passed since the last send.
+        Otherwise schedules a send at the next frame boundary, coalescing
+        any intermediate updates into a single frame.
+        """
+        import time
+
+        now = time.monotonic()
+        elapsed = now - self._last_send_time
+
+        if elapsed >= self._frame_interval:
+            # Enough time has passed, send immediately
+            if self._send_timer is not None:
+                self._send_timer.cancel()
+                self._send_timer = None
+            self._do_send()
+        elif self._send_timer is None and self._hass:
+            # Schedule send at next frame boundary
+            remaining = self._frame_interval - elapsed
+            self._send_timer = self._hass.loop.call_later(remaining, self._do_send)
 
     def _do_send(self) -> None:
+        import time
+
         self._send_timer = None
+        self._last_send_time = time.monotonic()
         self.send_universe_data()
 
     @staticmethod

--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -49,6 +49,7 @@ class DmxUniverse:
                 self.sacn_server.terminate_universe(self.sacn_universe)
             else:
                 self.sacn_server.add_universe(self.sacn_universe)
+                self.send_universe_data()
 
     def is_output_enabled(self) -> bool:
         return self._output_enabled

--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -44,6 +44,11 @@ class DmxUniverse:
 
     def set_output_enabled(self, enabled: bool) -> None:
         self._output_enabled = enabled
+        if self.sacn_server and self.sacn_universe:
+            if not enabled:
+                self.sacn_server.terminate_universe(self.sacn_universe)
+            else:
+                self.sacn_server.add_universe(self.sacn_universe)
 
     def is_output_enabled(self) -> bool:
         return self._output_enabled

--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -135,10 +135,14 @@ class DmxUniverse:
                 self._send_timer.cancel()
                 self._send_timer = None
             self._do_send()
-        elif self._send_timer is None and self._hass:
-            # Schedule send at next frame boundary
-            remaining = self._frame_interval - elapsed
-            self._send_timer = self._hass.loop.call_later(remaining, self._do_send)
+        elif self._send_timer is None:
+            if self._hass:
+                # Schedule send at next frame boundary
+                remaining = self._frame_interval - elapsed
+                self._send_timer = self._hass.loop.call_later(remaining, self._do_send)
+            else:
+                # No event loop available (e.g. unit tests); send synchronously
+                self._do_send()
 
     def _do_send(self) -> None:
         import time
@@ -156,6 +160,9 @@ class DmxUniverse:
 
     def get_channel_value(self, channel: int) -> int:
         return self._channel_values.get(channel, 0)
+
+    def is_channel_set(self, channel: int) -> bool:
+        return channel in self._channel_values
 
     def send_universe_data(self) -> None:
         if not self._output_enabled:

--- a/custom_components/dmx/server/artnet_server.py
+++ b/custom_components/dmx/server/artnet_server.py
@@ -763,6 +763,14 @@ class ArtNetServer(asyncio.DatagramProtocol):
             log.debug(f"Received ArtDmx for port address that we don't care about: {dmx.port_address}")
             return
 
+        # Ignore packets we sent ourselves (loopback). Without this guard, our own
+        # retransmits and any echoed copies fan into state_callback and overwrite
+        # _channel_values, which can wipe out a user-initiated update before the
+        # entity's UI state has settled.
+        if sender_addr and inet_aton(sender_addr[0]) == self._own_ip:
+            log.debug(f"Ignoring ArtDmx loopback from {sender_addr[0]} for {dmx.port_address}")
+            return
+
         if not own_port.port.good_input.data_received:
             own_port.port.good_input.data_received = True
             self.update_subscribers()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "netifaces",
-    "homeassistant-stubs==2025.9.1",
+    "homeassistant-stubs==2026.2.3",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
When a HA light group sends turn_on to multiple fixtures on the same universe, each fixture calls update_multiple_values() which immediately sends a full DMX frame. This creates a burst of frames in <1ms where intermediate frames contain incomplete state, causing random subsets of fixtures to not respond.

Add a 50ms debounce via call_later so that rapid successive updates are coalesced into a single DMX frame containing the complete state.

This was observed with an Obsidian EP2 EtherDMX node and 6 QR-530V RGBW fixtures.