### PR TITLE
Guard against None rgb_color when restoring state

### DIFF
--- a/custom_components/dmx/entity/light/light_entity.py
+++ b/custom_components/dmx/entity/light/light_entity.py
@@ -166,8 +166,9 @@ class DmxLightEntity(LightEntity, RestoreEntity):
 
         if "rgb_color" in attrs:
             rgb = attrs["rgb_color"]
-            self._state.rgb = rgb
-            self._state.last_rgb = rgb
+            if rgb is not None:
+                self._state.rgb = rgb
+                self._state.last_rgb = rgb
 
         if "color_temp_kelvin" in attrs:
             color_temp_kelvin = attrs["color_temp_kelvin"]


### PR DESCRIPTION
When a light is turned off, HA stores rgb_color as null. On restart, async_added_to_hass restores this null into last_rgb, overwriting the default (255, 255, 255). A subsequent turn_on without explicit color calls _restore_previous_state which tries to unpack last_rgb=None, resulting in no DMX output and the light staying dark.

Add a None check consistent with the existing brightness and color_temp_kelvin guards.