### PR TITLE
Terminate sACN stream when universe output is disabled

### DIFF
--- a/custom_components/dmx/io/dmx_io.py
+++ b/custom_components/dmx/io/dmx_io.py
@@ -40,6 +40,11 @@ class DmxUniverse:
 
     def set_output_enabled(self, enabled: bool) -> None:
         self._output_enabled = enabled
+        if self.sacn_server and self.sacn_universe:
+            if not enabled:
+                self.sacn_server.terminate_universe(self.sacn_universe)
+            else:
+                self.sacn_server.add_universe(self.sacn_universe)
 
     def is_output_enabled(self) -> bool:
         return self._output_enabled


### PR DESCRIPTION
## Summary
- When the universe switch is turned off, `set_output_enabled(False)` only prevented new frames from being sent via `send_universe_data()`. The sACN server's streaming task continued retransmitting the last frame every 0.8s.
- Now calls `terminate_universe()` when disabling, which cancels the retransmit task and sends the E1.31 stream termination packet (3x per spec)
- When re-enabling, calls `add_universe()` so the stream restarts on the next `send_universe_data()`

## Test plan
- [ ] Turn off a DMX universe switch and verify sACN packets stop (e.g. with Wireshark or sACN viewer)
- [ ] Verify termination packets are sent on disable
- [ ] Turn the switch back on, control a light, verify sACN streaming resumes
- [ ] Verify other universes are not affected