### PR TITLE
Fix fixed light entity metadata

### DIFF
--- a/custom_components/artnet_led/light.py
+++ b/custom_components/artnet_led/light.py
@@ -254,7 +254,7 @@ class DmxBaseLight(LightEntity, RestoreEntity):
         self._channel_size = CHANNEL_SIZE[kwargs[CONF_CHANNEL_SIZE]]
         self._color_mode = kwargs[CONF_DEVICE_TYPE]
         self._vals = []
-        self._features = 0
+        self._features = LightEntityFeature(0)
         self._supported_color_modes = set()
         self._channel_last_update = 0
         self._channel_width = 0
@@ -450,6 +450,7 @@ class DmxFixed(DmxBaseLight):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._color_mode = ColorMode.ONOFF
+        self._supported_color_modes.add(ColorMode.ONOFF)
         self._channel_setup = kwargs.get(CONF_CHANNEL_SETUP) or [255]
         self._channel_width = len(self._channel_setup)
 


### PR DESCRIPTION
Fixes #76.

This updates the legacy fixed-light entity metadata so Home Assistant no longer sees `DmxFixed` entities as having an empty supported color mode set or a plain integer supported-feature value.

Changes:
- initialize base supported features as `LightEntityFeature(0)` instead of raw `0`
- add `ColorMode.ONOFF` to `DmxFixed.supported_color_modes`

I kept this intentionally small because fixed channels should still behave as constant DMX outputs; this only changes the entity metadata HA validates.