### PR TITLE
Add DMX Patch panel with live-updating UI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,22 @@ The DMX integration for Home Assistant allows you to send DMX values to an [Art-
 8. _DOWNLOAD_
 9. Restart Home Assistant (_Settings_ > _System_ >  _RESTART_)
 
-## Configuration
+## DMX Patch panel (UI configuration)
+
+Since v0.2.0 the integration ships a **DMX Patch** panel in the Home Assistant sidebar (admin users only). It is a visual patch editor that replaces the need for YAML:
+
+* **Nodes**: add Art-Net/sACN/KiNet nodes with all their options (protocol, host, port, max FPS, refresh interval).
+* **Universes**: a 512-channel grid per universe. Click an empty channel to place a fixture, click a fixture to edit or delete it. Channel overlaps are highlighted and rejected on save.
+* **Live apply**: *Save & Apply* takes effect immediately — no Home Assistant restart. Entities keep their identity across saves (unique IDs are derived from `host/universe/channel`, so moving a fixture to another channel creates a new entity).
+* **Live DMX values**: toggle *Live DMX values* on any universe to watch the actual channel values update in real time (10 Hz).
+
+The first *Save & Apply* automatically creates the *DMX Patch* config entry (also available via *Settings → Devices & Services → Add integration → DMX Artnet integration*). The patch itself is stored in `.storage/artnet_led.patch`.
+
+### Coexistence with YAML
+
+Existing YAML configuration keeps working unchanged. YAML-defined nodes appear in the panel read-only (🔒), with live monitoring available. A node (`host:port`) can be owned by either YAML or the panel, not both — the panel will refuse to save a node that is already configured in YAML. To migrate a node from YAML to the UI, remove it from `configuration.yaml`, restart once, then recreate it in the panel (entities keep their history as long as names and channels stay the same).
+
+## Configuration (YAML)
 
 hass-dmx is a community supported Home Assistant integration, if you have any questions you can discuss with the [Home Assistant DMX Community](https://community.home-assistant.io/t/dmx-lighting/2248).
 

--- a/custom_components/artnet_led/__init__.py
+++ b/custom_components/artnet_led/__init__.py
@@ -1,1 +1,139 @@
 """ARTNET LED"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from homeassistant.components.http import StaticPathConfig
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from custom_components.artnet_led.const import (
+    DATA_ENTRY_NODES,
+    DATA_MONITOR,
+    DATA_STORE,
+    DOMAIN,
+    FRONTEND_STATIC_PATH,
+    PANEL_ICON,
+    PANEL_TITLE,
+    PANEL_URL_PATH,
+    PANEL_WEBCOMPONENT_NAME,
+)
+from custom_components.artnet_led.runtime import ArtNetRuntime, NodeConflictError
+from custom_components.artnet_led.store import PatchStore
+
+log = logging.getLogger(__name__)
+
+PLATFORMS = ["light"]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Shared setup: runs for YAML-only installs and before any config entry."""
+    data = hass.data.setdefault(DOMAIN, {})
+
+    ArtNetRuntime.get(hass)
+    data.setdefault(DATA_ENTRY_NODES, {})
+    if DATA_STORE not in data:
+        data[DATA_STORE] = PatchStore(hass)
+
+    if DATA_MONITOR not in data:
+        from custom_components.artnet_led.monitor import DmxMonitor
+
+        data[DATA_MONITOR] = DmxMonitor(hass)
+
+    if not data.get("ws_registered"):
+        from custom_components.artnet_led.websocket_api import async_register_commands
+
+        async_register_commands(hass)
+        data["ws_registered"] = True
+
+    if not data.get("panel_registered"):
+        await _async_register_panel(hass)
+        data["panel_registered"] = True
+
+    return True
+
+
+async def _async_register_panel(hass: HomeAssistant) -> None:
+    from homeassistant.components.panel_custom import async_register_panel
+
+    dist_path = Path(__file__).parent / "frontend" / "dist"
+    if not (dist_path / "panel.js").exists():
+        log.warning("Panel frontend bundle missing (%s); DMX Patch panel not registered",
+                    dist_path / "panel.js")
+        return
+
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(FRONTEND_STATIC_PATH, str(dist_path), cache_headers=False)]
+    )
+
+    from homeassistant.loader import async_get_integration
+
+    integration = await async_get_integration(hass, DOMAIN)
+
+    await async_register_panel(
+        hass,
+        frontend_url_path=PANEL_URL_PATH,
+        webcomponent_name=PANEL_WEBCOMPONENT_NAME,
+        module_url=f"{FRONTEND_STATIC_PATH}/panel.js?v={integration.version}",
+        sidebar_title=PANEL_TITLE,
+        sidebar_icon=PANEL_ICON,
+        require_admin=True,
+    )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the UI-defined patch from storage."""
+    from custom_components.artnet_led.validation import (
+        patch_node_to_setup_config,
+        validate_patch,
+    )
+
+    # async_setup always runs first, but be defensive about ordering.
+    await async_setup(hass, {})
+
+    runtime = ArtNetRuntime.get(hass)
+    store: PatchStore = hass.data[DOMAIN][DATA_STORE]
+    patch = await store.async_load()
+
+    errors = validate_patch(hass, patch, runtime)
+    if errors:
+        log.error("Stored DMX patch has %d validation error(s); "
+                  "invalid nodes will be skipped: %s", len(errors), errors)
+
+    error_node_indices = {
+        int(e["path"].split("/")[1])
+        for e in errors
+        if e["path"].startswith("nodes/") and e["path"].split("/")[1].isdigit()
+    }
+
+    entry_nodes = []
+    for i, node in enumerate(patch.get("nodes", [])):
+        if i in error_node_indices:
+            log.warning("Skipping patch node %d (%s) due to validation errors",
+                        i, node.get("host"))
+            continue
+        cfg = patch_node_to_setup_config(node)
+        try:
+            handle = await runtime.acquire_node(cfg, owner=entry.entry_id)
+        except NodeConflictError as e:
+            log.error("Skipping patch node %d: %s", i, e)
+            continue
+        entry_nodes.append((handle, cfg["universes"]))
+
+    hass.data[DOMAIN][DATA_ENTRY_NODES][entry.entry_id] = entry_nodes
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Tear down the entry's entities and nodes so a reload can rebuild them."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    runtime = ArtNetRuntime.get(hass)
+    await runtime.release_owner(entry.entry_id)
+    hass.data[DOMAIN][DATA_ENTRY_NODES].pop(entry.entry_id, None)
+
+    return unload_ok

--- a/custom_components/artnet_led/bridge/artnet_controller.py
+++ b/custom_components/artnet_led/bridge/artnet_controller.py
@@ -52,8 +52,18 @@ class ArtNetController(BaseNode):
         self.__server.add_port(PortAddress.parse(nr))
         return dmx_universe
 
+    @property
+    def server(self) -> ArtNetServer:
+        return self.__server
+
     def start(self):
         return self.__server.start_server()
+
+    async def stop(self):
+        await self.__server.stop()
+        # BaseNode.__aexit__ cancels the process/refresh tasks; the socket was never
+        # opened for the controller (start() is used instead of __aenter__).
+        await super().__aexit__(None, None, None)
 
     def get_universe(self, nr: int) -> UniverseBridge:
         return super().get_universe(nr)

--- a/custom_components/artnet_led/client/artnet_server.py
+++ b/custom_components/artnet_led/client/artnet_server.py
@@ -85,6 +85,13 @@ class ArtNetServer(asyncio.DatagramProtocol):
         self.__hass = hass
         self.__state_update_callback = state_update_callback
         self.__new_node_callback = new_node_callback
+        # Optional hook fired for every inbound ArtDmx packet (used by the DMX monitor).
+        self.dmx_received_callback = None
+
+        self._transport: transports.DatagramTransport | None = None
+        self._endpoint_task: Task | None = None
+        self._poll_task: Task | None = None
+        self._misc_tasks: set[Task] = set()
         self.firmware_version = firmware_version
         self.oem = oem
         self.esta = esta
@@ -210,10 +217,56 @@ class ArtNetServer(asyncio.DatagramProtocol):
         server_event = loop.create_datagram_endpoint(lambda: self, local_addr=('0.0.0.0', ARTNET_PORT))
 
         if self._polling:
-            self.__hass.async_create_background_task(self.start_poll_loop(), "Art-Net polling loop")
+            self._poll_task = self.__hass.async_create_background_task(
+                self.start_poll_loop(), "Art-Net polling loop"
+            )
         log.info("ArtNet server started")
 
-        return self.__hass.async_create_task(server_event)
+        self._endpoint_task = self.__hass.async_create_task(server_event)
+        return self._endpoint_task
+
+    def _track_task(self, task: Task) -> Task:
+        self._misc_tasks.add(task)
+        task.add_done_callback(self._misc_tasks.discard)
+        return task
+
+    async def stop(self):
+        """Stop all background work and close the UDP socket so the port can be rebound."""
+        if self._poll_task:
+            self._poll_task.cancel()
+            self._poll_task = None
+
+        for task in list(self._misc_tasks):
+            task.cancel()
+        if self._misc_tasks:
+            await asyncio.gather(*self._misc_tasks, return_exceptions=True)
+            self._misc_tasks.clear()
+
+        for own_port in self.own_port_addresses.values():
+            if own_port.update_task:
+                own_port.update_task.cancel()
+                own_port.update_task = None
+
+        # Make sure the endpoint finished being created before closing its transport.
+        if self._endpoint_task and not self._endpoint_task.done():
+            try:
+                await self._endpoint_task
+            except Exception:
+                pass
+        self._endpoint_task = None
+
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+            # Give the event loop a beat to process the close, so UDP 6454 can be rebound.
+            await asyncio.sleep(0)
+
+        self.own_port_addresses.clear()
+        self.nodes_by_ip.clear()
+        self.nodes_by_port_address.clear()
+        self.node_change_subscribers.clear()
+
+        log.info("ArtNet server stopped")
 
     async def start_poll_loop(self):
         while True:
@@ -230,7 +283,11 @@ class ArtNetServer(asyncio.DatagramProtocol):
                     sock.setblocking(False)
                     sock.sendto(poll.serialize(), ("255.255.255.255", 0x1936))
 
-                self.__hass.async_create_background_task(self.remove_stale_nodes(), "Art-Net remove stale nodes")
+                self._track_task(
+                    self.__hass.async_create_background_task(
+                        self.remove_stale_nodes(), "Art-Net remove stale nodes"
+                    )
+                )
 
                 log.debug("Sleeping a few seconds before polling again...")
             await asyncio.sleep(random.uniform(2.5, 3))
@@ -365,6 +422,7 @@ class ArtNetServer(asyncio.DatagramProtocol):
 
     def connection_made(self, transport: transports.DatagramTransport) -> None:
         self.startup_time = datetime.datetime.now()
+        self._transport = transport
         log.debug("Server connection made")
         super().connection_made(transport)
 
@@ -582,9 +640,11 @@ class ArtNetServer(asyncio.DatagramProtocol):
             self.update_subscribers()
 
         own_port.port.last_input_seen = datetime.datetime.now()
-        self.__hass.async_create_task(self.disable_input_flag(own_port))
+        self._track_task(self.__hass.async_create_task(self.disable_input_flag(own_port)))
         if self.__state_update_callback:
             self.__state_update_callback(dmx.port_address, dmx.data)
+        if self.dmx_received_callback:
+            self.dmx_received_callback(dmx.port_address, dmx.data)
 
     async def disable_input_flag(self, own_port: OwnPort):
         await asyncio.sleep(4)

--- a/custom_components/artnet_led/config_flow.py
+++ b/custom_components/artnet_led/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flow: a single 'DMX Patch' entry that anchors the UI-defined configuration."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+
+from custom_components.artnet_led.const import DOMAIN
+
+
+class ArtnetLedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title="DMX Patch", data={})
+
+    async def async_step_import(self, import_data=None):
+        """Created programmatically when the panel saves its first patch."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+        return self.async_create_entry(title="DMX Patch", data={})

--- a/custom_components/artnet_led/const.py
+++ b/custom_components/artnet_led/const.py
@@ -1,0 +1,78 @@
+"""Shared constants for the Art-Net LED integration."""
+from __future__ import annotations
+
+import pyartnet
+
+DOMAIN = "artnet_led"
+
+# Historical unique_id prefix; light.py used to call this DOMAIN ("dmx").
+# It is baked into every existing entity's unique_id, so it must never change.
+UNIQUE_ID_PREFIX = "dmx"
+
+DATA_RUNTIME = "runtime"
+DATA_STORE = "store"
+DATA_ENTRY_NODES = "entry_nodes"
+DATA_MONITOR = "monitor"
+DATA_STOP_LISTENER = "stop_listener"
+
+STORAGE_KEY = "artnet_led.patch"
+STORAGE_VERSION = 1
+
+OWNER_YAML = "yaml"
+
+ARTNET_DEFAULT_PORT = 6454
+SACN_DEFAULT_PORT = 5568
+KINET_DEFAULT_PORT = 6038
+
+NODE_TYPE_ARTNET_DIRECT = "artnet-direct"
+NODE_TYPE_ARTNET_CONTROLLER = "artnet-controller"
+NODE_TYPE_SACN = "sacn"
+NODE_TYPE_KINET = "kinet"
+
+NODE_TYPES = [
+    NODE_TYPE_ARTNET_DIRECT,
+    NODE_TYPE_ARTNET_CONTROLLER,
+    NODE_TYPE_SACN,
+    NODE_TYPE_KINET,
+]
+
+CONF_NODE_TYPE = "node_type"
+CONF_NODE_MAX_FPS = "max_fps"
+CONF_NODE_REFRESH = "refresh_every"
+CONF_NODE_UNIVERSES = "universes"
+CONF_NODE_HOST_OVERRIDE = "host_override"
+CONF_NODE_PORT_OVERRIDE = "port_override"
+
+CONF_SEND_PARTIAL_UNIVERSE = "send_partial_universe"
+
+CONF_DEVICE_CHANNEL = "channel"
+CONF_OUTPUT_CORRECTION = "output_correction"
+CONF_CHANNEL_SIZE = "channel_size"
+CONF_BYTE_ORDER = "byte_order"
+CONF_DEVICE_MIN_TEMP = "min_temp"
+CONF_DEVICE_MAX_TEMP = "max_temp"
+CONF_CHANNEL_SETUP = "channel_setup"
+
+AVAILABLE_CORRECTIONS = {
+    "linear": pyartnet.output_correction.linear,
+    "quadratic": pyartnet.output_correction.quadratic,
+    "cubic": pyartnet.output_correction.cubic,
+    "quadruple": pyartnet.output_correction.quadruple,
+}
+
+type LogicalChannelSize = int
+type LogicalChannelNumBytes = int
+type ChannelSize = tuple[LogicalChannelSize, LogicalChannelNumBytes]
+
+CHANNEL_SIZE: dict[str, ChannelSize] = {
+    "8bit": (1, 1),
+    "16bit": (2, 256),
+    "24bit": (3, 256 ** 2),
+    "32bit": (4, 256 ** 3),
+}
+
+PANEL_URL_PATH = "dmx-patch"
+PANEL_TITLE = "DMX Patch"
+PANEL_ICON = "mdi:spotlight-beam"
+PANEL_WEBCOMPONENT_NAME = "artnet-patch-panel"
+FRONTEND_STATIC_PATH = "/artnet_led_panel"

--- a/custom_components/artnet_led/entity_factory.py
+++ b/custom_components/artnet_led/entity_factory.py
@@ -1,0 +1,106 @@
+"""Builds pyartnet universes/channels and HA light entities from a parsed universes config.
+
+Shared by the YAML platform path and the config-entry (UI patch) path so both
+produce identical entities with identical unique_ids.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.const import CONF_DEVICES
+from homeassistant.const import CONF_NAME as CONF_DEVICE_NAME
+from homeassistant.const import CONF_TYPE as CONF_DEVICE_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import async_get
+from homeassistant.util import slugify
+from pyartnet import BaseUniverse
+from pyartnet.errors import UniverseNotFoundError
+
+from custom_components.artnet_led.const import (
+    AVAILABLE_CORRECTIONS,
+    CHANNEL_SIZE,
+    CONF_BYTE_ORDER,
+    CONF_CHANNEL_SIZE,
+    CONF_DEVICE_CHANNEL,
+    CONF_OUTPUT_CORRECTION,
+    CONF_SEND_PARTIAL_UNIVERSE,
+    UNIQUE_ID_PREFIX,
+)
+
+log = logging.getLogger(__name__)
+
+
+def create_light_entities(
+    hass: HomeAssistant,
+    node,
+    host: str,
+    universes_cfg: dict[int, dict],
+    used_unique_ids: list[str] | None = None,
+) -> list:
+    """Create (or reuse) universes/channels on ``node`` and return the light entities."""
+    # Imported late: light.py imports this module during setup, so a top-level
+    # import here would be circular.
+    from custom_components.artnet_led.light import CLASS_TYPE
+
+    entity_registry = async_get(hass)
+
+    device_list = []
+    if used_unique_ids is None:
+        used_unique_ids = []
+
+    for universe_nr, universe_cfg in universes_cfg.items():
+        try:
+            universe = node.get_universe(universe_nr)
+        except UniverseNotFoundError:
+            universe: BaseUniverse = node.add_universe(universe_nr)
+            universe.set_output_correction(AVAILABLE_CORRECTIONS.get(
+                universe_cfg[CONF_OUTPUT_CORRECTION]
+            ))
+
+        for device in universe_cfg[CONF_DEVICES]:  # type: dict
+            device = device.copy()
+            cls = CLASS_TYPE[device[CONF_DEVICE_TYPE]]
+
+            channel = device[CONF_DEVICE_CHANNEL]
+            unique_id = f"{UNIQUE_ID_PREFIX}:{host}/{universe_nr}/{channel}"
+
+            name: str = device[CONF_DEVICE_NAME]
+            byte_size = CHANNEL_SIZE[device[CONF_CHANNEL_SIZE]][0]
+            byte_order = device[CONF_BYTE_ORDER]
+
+            entity_id = f"light.{slugify(name)}"
+
+            # If the entity has another unique ID, use that until it's migrated properly
+            entity = entity_registry.async_get(entity_id)
+            if entity:
+                log.info(f"Found existing entity for name {entity_id}, using unique id {unique_id}")
+                if entity.unique_id is not None and entity.unique_id not in used_unique_ids:
+                    unique_id = entity.unique_id
+            used_unique_ids.append(unique_id)
+
+            # create device
+            device["unique_id"] = unique_id
+            d = cls(**device)
+            d.set_type(device[CONF_DEVICE_TYPE])
+
+            d.set_channel(
+                universe.add_channel(
+                    start=channel,
+                    width=d.channel_width,
+                    channel_name=d.name,
+                    byte_size=byte_size,
+                    byte_order=byte_order,
+                )
+            )
+
+            d.channel.set_output_correction(AVAILABLE_CORRECTIONS.get(
+                device[CONF_OUTPUT_CORRECTION]
+            ))
+
+            device_list.append(d)
+
+            send_partial_universe = universe_cfg[CONF_SEND_PARTIAL_UNIVERSE]
+            if not send_partial_universe:
+                universe._resize_universe(512)
+
+    return device_list

--- a/custom_components/artnet_led/frontend/.gitignore
+++ b/custom_components/artnet_led/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+# The repo-root .gitignore excludes dist/ globally, but this bundle is shipped
+# to users via HACS and must be committed.
+!dist/

--- a/custom_components/artnet_led/frontend/README.md
+++ b/custom_components/artnet_led/frontend/README.md
@@ -1,0 +1,17 @@
+# DMX Patch panel frontend
+
+Lit-based custom panel served by the integration at `/artnet_led_panel/panel.js`.
+
+The bundled `dist/panel.js` is **committed** so HACS installs need no build step.
+After changing anything in `src/`, rebuild and commit the bundle:
+
+```sh
+npm install
+npm run build
+```
+
+`npm run watch` rebuilds on save during development.
+
+All colors use Home Assistant theme CSS custom properties so the panel follows
+light/dark themes. No external resources are loaded (HA's CSP forbids CDNs);
+Lit is vendored into the bundle.

--- a/custom_components/artnet_led/frontend/dist/panel.js
+++ b/custom_components/artnet_led/frontend/dist/panel.js
@@ -1,0 +1,835 @@
+var Le=Object.defineProperty;var ze=Object.getOwnPropertyDescriptor;var h=(o,e,t,s)=>{for(var i=s>1?void 0:s?ze(e,t):e,n=o.length-1,r;n>=0;n--)(r=o[n])&&(i=(s?r(e,t,i):r(i))||i);return s&&i&&Le(e,t,i),i};var Y=globalThis,B=Y.ShadowRoot&&(Y.ShadyCSS===void 0||Y.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,J=Symbol(),de=new WeakMap,H=class{constructor(e,t,s){if(this._$cssResult$=!0,s!==J)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o,t=this.t;if(B&&e===void 0){let s=t!==void 0&&t.length===1;s&&(e=de.get(t)),e===void 0&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),s&&de.set(t,e))}return e}toString(){return this.cssText}},he=o=>new H(typeof o=="string"?o:o+"",void 0,J),k=(o,...e)=>{let t=o.length===1?o[0]:e.reduce((s,i,n)=>s+(r=>{if(r._$cssResult$===!0)return r.cssText;if(typeof r=="number")return r;throw Error("Value passed to 'css' function must be a 'css' function result: "+r+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+o[n+1],o[0]);return new H(t,o,J)},pe=(o,e)=>{if(B)o.adoptedStyleSheets=e.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(let t of e){let s=document.createElement("style"),i=Y.litNonce;i!==void 0&&s.setAttribute("nonce",i),s.textContent=t.cssText,o.appendChild(s)}},Q=B?o=>o:o=>o instanceof CSSStyleSheet?(e=>{let t="";for(let s of e.cssRules)t+=s.cssText;return he(t)})(o):o;var{is:Ie,defineProperty:je,getOwnPropertyDescriptor:qe,getOwnPropertyNames:Ye,getOwnPropertySymbols:Be,getPrototypeOf:Ke}=Object,K=globalThis,ue=K.trustedTypes,We=ue?ue.emptyScript:"",Fe=K.reactiveElementPolyfillSupport,D=(o,e)=>o,O={toAttribute(o,e){switch(e){case Boolean:o=o?We:null;break;case Object:case Array:o=o==null?o:JSON.stringify(o)}return o},fromAttribute(o,e){let t=o;switch(e){case Boolean:t=o!==null;break;case Number:t=o===null?null:Number(o);break;case Object:case Array:try{t=JSON.parse(o)}catch{t=null}}return t}},W=(o,e)=>!Ie(o,e),ve={attribute:!0,type:String,converter:O,reflect:!1,useDefault:!1,hasChanged:W};Symbol.metadata??=Symbol("metadata"),K.litPropertyMetadata??=new WeakMap;var y=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=ve){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){let s=Symbol(),i=this.getPropertyDescriptor(e,s,t);i!==void 0&&je(this.prototype,e,i)}}static getPropertyDescriptor(e,t,s){let{get:i,set:n}=qe(this.prototype,e)??{get(){return this[t]},set(r){this[t]=r}};return{get:i,set(r){let a=i?.call(this);n?.call(this,r),this.requestUpdate(e,a,s)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??ve}static _$Ei(){if(this.hasOwnProperty(D("elementProperties")))return;let e=Ke(this);e.finalize(),e.l!==void 0&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(D("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(D("properties"))){let t=this.properties,s=[...Ye(t),...Be(t)];for(let i of s)this.createProperty(i,t[i])}let e=this[Symbol.metadata];if(e!==null){let t=litPropertyMetadata.get(e);if(t!==void 0)for(let[s,i]of t)this.elementProperties.set(s,i)}this._$Eh=new Map;for(let[t,s]of this.elementProperties){let i=this._$Eu(t,s);i!==void 0&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){let t=[];if(Array.isArray(e)){let s=new Set(e.flat(1/0).reverse());for(let i of s)t.unshift(Q(i))}else e!==void 0&&t.push(Q(e));return t}static _$Eu(e,t){let s=t.attribute;return s===!1?void 0:typeof s=="string"?s:typeof e=="string"?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),this.renderRoot!==void 0&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){let e=new Map,t=this.constructor.elementProperties;for(let s of t.keys())this.hasOwnProperty(s)&&(e.set(s,this[s]),delete this[s]);e.size>0&&(this._$Ep=e)}createRenderRoot(){let e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return pe(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,s){this._$AK(e,s)}_$ET(e,t){let s=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,s);if(i!==void 0&&s.reflect===!0){let n=(s.converter?.toAttribute!==void 0?s.converter:O).toAttribute(t,s.type);this._$Em=e,n==null?this.removeAttribute(i):this.setAttribute(i,n),this._$Em=null}}_$AK(e,t){let s=this.constructor,i=s._$Eh.get(e);if(i!==void 0&&this._$Em!==i){let n=s.getPropertyOptions(i),r=typeof n.converter=="function"?{fromAttribute:n.converter}:n.converter?.fromAttribute!==void 0?n.converter:O;this._$Em=i;let a=r.fromAttribute(t,n.type);this[i]=a??this._$Ej?.get(i)??a,this._$Em=null}}requestUpdate(e,t,s,i=!1,n){if(e!==void 0){let r=this.constructor;if(i===!1&&(n=this[e]),s??=r.getPropertyOptions(e),!((s.hasChanged??W)(n,t)||s.useDefault&&s.reflect&&n===this._$Ej?.get(e)&&!this.hasAttribute(r._$Eu(e,s))))return;this.C(e,t,s)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(e,t,{useDefault:s,reflect:i,wrapped:n},r){s&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,r??t??this[e]),n!==!0||r!==void 0)||(this._$AL.has(e)||(this.hasUpdated||s||(t=void 0),this._$AL.set(e,t)),i===!0&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}let e=this.scheduleUpdate();return e!=null&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(let[i,n]of this._$Ep)this[i]=n;this._$Ep=void 0}let s=this.constructor.elementProperties;if(s.size>0)for(let[i,n]of s){let{wrapped:r}=n,a=this[i];r!==!0||this._$AL.has(i)||a===void 0||this.C(i,void 0,n,a)}}let e=!1,t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(s=>s.hostUpdate?.()),this.update(t)):this._$EM()}catch(s){throw e=!1,this._$EM(),s}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(e){}firstUpdated(e){}};y.elementStyles=[],y.shadowRootOptions={mode:"open"},y[D("elementProperties")]=new Map,y[D("finalized")]=new Map,Fe?.({ReactiveElement:y}),(K.reactiveElementVersions??=[]).push("2.1.2");var oe=globalThis,me=o=>o,F=oe.trustedTypes,_e=F?F.createPolicy("lit-html",{createHTML:o=>o}):void 0,xe="$lit$",S=`lit$${Math.random().toFixed(9).slice(2)}$`,Ee="?"+S,Ve=`<${Ee}>`,C=document,L=()=>C.createComment(""),z=o=>o===null||typeof o!="object"&&typeof o!="function",ne=Array.isArray,Xe=o=>ne(o)||typeof o?.[Symbol.iterator]=="function",G=`[ 	
+\f\r]`,R=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,fe=/-->/g,ge=/>/g,N=RegExp(`>|${G}(?:([^\\s"'>=/]+)(${G}*=${G}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),be=/'/g,$e=/"/g,we=/^(?:script|style|textarea|title)$/i,ae=o=>(e,...t)=>({_$litType$:o,strings:e,values:t}),d=ae(1),ct=ae(2),dt=ae(3),P=Symbol.for("lit-noChange"),c=Symbol.for("lit-nothing"),ye=new WeakMap,A=C.createTreeWalker(C,129);function Se(o,e){if(!ne(o)||!o.hasOwnProperty("raw"))throw Error("invalid template strings array");return _e!==void 0?_e.createHTML(e):e}var Ze=(o,e)=>{let t=o.length-1,s=[],i,n=e===2?"<svg>":e===3?"<math>":"",r=R;for(let a=0;a<t;a++){let l=o[a],u,f,p=-1,$=0;for(;$<l.length&&(r.lastIndex=$,f=r.exec(l),f!==null);)$=r.lastIndex,r===R?f[1]==="!--"?r=fe:f[1]!==void 0?r=ge:f[2]!==void 0?(we.test(f[2])&&(i=RegExp("</"+f[2],"g")),r=N):f[3]!==void 0&&(r=N):r===N?f[0]===">"?(r=i??R,p=-1):f[1]===void 0?p=-2:(p=r.lastIndex-f[2].length,u=f[1],r=f[3]===void 0?N:f[3]==='"'?$e:be):r===$e||r===be?r=N:r===fe||r===ge?r=R:(r=N,i=void 0);let w=r===N&&o[a+1].startsWith("/>")?" ":"";n+=r===R?l+Ve:p>=0?(s.push(u),l.slice(0,p)+xe+l.slice(p)+S+w):l+S+(p===-2?a:w)}return[Se(o,n+(o[t]||"<?>")+(e===2?"</svg>":e===3?"</math>":"")),s]},I=class o{constructor({strings:e,_$litType$:t},s){let i;this.parts=[];let n=0,r=0,a=e.length-1,l=this.parts,[u,f]=Ze(e,t);if(this.el=o.createElement(u,s),A.currentNode=this.el.content,t===2||t===3){let p=this.el.content.firstChild;p.replaceWith(...p.childNodes)}for(;(i=A.nextNode())!==null&&l.length<a;){if(i.nodeType===1){if(i.hasAttributes())for(let p of i.getAttributeNames())if(p.endsWith(xe)){let $=f[r++],w=i.getAttribute(p).split(S),q=/([.?@])?(.*)/.exec($);l.push({type:1,index:n,name:q[2],strings:w,ctor:q[1]==="."?te:q[1]==="?"?se:q[1]==="@"?ie:M}),i.removeAttribute(p)}else p.startsWith(S)&&(l.push({type:6,index:n}),i.removeAttribute(p));if(we.test(i.tagName)){let p=i.textContent.split(S),$=p.length-1;if($>0){i.textContent=F?F.emptyScript:"";for(let w=0;w<$;w++)i.append(p[w],L()),A.nextNode(),l.push({type:2,index:++n});i.append(p[$],L())}}}else if(i.nodeType===8)if(i.data===Ee)l.push({type:2,index:n});else{let p=-1;for(;(p=i.data.indexOf(S,p+1))!==-1;)l.push({type:7,index:n}),p+=S.length-1}n++}}static createElement(e,t){let s=C.createElement("template");return s.innerHTML=e,s}};function U(o,e,t=o,s){if(e===P)return e;let i=s!==void 0?t._$Co?.[s]:t._$Cl,n=z(e)?void 0:e._$litDirective$;return i?.constructor!==n&&(i?._$AO?.(!1),n===void 0?i=void 0:(i=new n(o),i._$AT(o,t,s)),s!==void 0?(t._$Co??=[])[s]=i:t._$Cl=i),i!==void 0&&(e=U(o,i._$AS(o,e.values),i,s)),e}var ee=class{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){let{el:{content:t},parts:s}=this._$AD,i=(e?.creationScope??C).importNode(t,!0);A.currentNode=i;let n=A.nextNode(),r=0,a=0,l=s[0];for(;l!==void 0;){if(r===l.index){let u;l.type===2?u=new j(n,n.nextSibling,this,e):l.type===1?u=new l.ctor(n,l.name,l.strings,this,e):l.type===6&&(u=new re(n,this,e)),this._$AV.push(u),l=s[++a]}r!==l?.index&&(n=A.nextNode(),r++)}return A.currentNode=C,i}p(e){let t=0;for(let s of this._$AV)s!==void 0&&(s.strings!==void 0?(s._$AI(e,s,t),t+=s.strings.length-2):s._$AI(e[t])),t++}},j=class o{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,s,i){this.type=2,this._$AH=c,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=s,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode,t=this._$AM;return t!==void 0&&e?.nodeType===11&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=U(this,e,t),z(e)?e===c||e==null||e===""?(this._$AH!==c&&this._$AR(),this._$AH=c):e!==this._$AH&&e!==P&&this._(e):e._$litType$!==void 0?this.$(e):e.nodeType!==void 0?this.T(e):Xe(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==c&&z(this._$AH)?this._$AA.nextSibling.data=e:this.T(C.createTextNode(e)),this._$AH=e}$(e){let{values:t,_$litType$:s}=e,i=typeof s=="number"?this._$AC(e):(s.el===void 0&&(s.el=I.createElement(Se(s.h,s.h[0]),this.options)),s);if(this._$AH?._$AD===i)this._$AH.p(t);else{let n=new ee(i,this),r=n.u(this.options);n.p(t),this.T(r),this._$AH=n}}_$AC(e){let t=ye.get(e.strings);return t===void 0&&ye.set(e.strings,t=new I(e)),t}k(e){ne(this._$AH)||(this._$AH=[],this._$AR());let t=this._$AH,s,i=0;for(let n of e)i===t.length?t.push(s=new o(this.O(L()),this.O(L()),this,this.options)):s=t[i],s._$AI(n),i++;i<t.length&&(this._$AR(s&&s._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){let s=me(e).nextSibling;me(e).remove(),e=s}}setConnected(e){this._$AM===void 0&&(this._$Cv=e,this._$AP?.(e))}},M=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,s,i,n){this.type=1,this._$AH=c,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=n,s.length>2||s[0]!==""||s[1]!==""?(this._$AH=Array(s.length-1).fill(new String),this.strings=s):this._$AH=c}_$AI(e,t=this,s,i){let n=this.strings,r=!1;if(n===void 0)e=U(this,e,t,0),r=!z(e)||e!==this._$AH&&e!==P,r&&(this._$AH=e);else{let a=e,l,u;for(e=n[0],l=0;l<n.length-1;l++)u=U(this,a[s+l],t,l),u===P&&(u=this._$AH[l]),r||=!z(u)||u!==this._$AH[l],u===c?e=c:e!==c&&(e+=(u??"")+n[l+1]),this._$AH[l]=u}r&&!i&&this.j(e)}j(e){e===c?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}},te=class extends M{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===c?void 0:e}},se=class extends M{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==c)}},ie=class extends M{constructor(e,t,s,i,n){super(e,t,s,i,n),this.type=5}_$AI(e,t=this){if((e=U(this,e,t,0)??c)===P)return;let s=this._$AH,i=e===c&&s!==c||e.capture!==s.capture||e.once!==s.once||e.passive!==s.passive,n=e!==c&&(s===c||i);i&&this.element.removeEventListener(this.name,this,s),n&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}},re=class{constructor(e,t,s){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=s}get _$AU(){return this._$AM._$AU}_$AI(e){U(this,e)}};var Je=oe.litHtmlPolyfillSupport;Je?.(I,j),(oe.litHtmlVersions??=[]).push("3.3.3");var ke=(o,e,t)=>{let s=t?.renderBefore??e,i=s._$litPart$;if(i===void 0){let n=t?.renderBefore??null;s._$litPart$=i=new j(e.insertBefore(L(),n),n,void 0,t??{})}return i._$AI(o),i};var le=globalThis,g=class extends y{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){let e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){let t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=ke(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return P}};g._$litElement$=!0,g.finalized=!0,le.litElementHydrateSupport?.({LitElement:g});var Qe=le.litElementPolyfillSupport;Qe?.({LitElement:g});(le.litElementVersions??=[]).push("4.2.2");var T=o=>(e,t)=>{t!==void 0?t.addInitializer(()=>{customElements.define(o,e)}):customElements.define(o,e)};var Ge={attribute:!0,type:String,converter:O,reflect:!1,hasChanged:W},et=(o=Ge,e,t)=>{let{kind:s,metadata:i}=t,n=globalThis.litPropertyMetadata.get(i);if(n===void 0&&globalThis.litPropertyMetadata.set(i,n=new Map),s==="setter"&&((o=Object.create(o)).wrapped=!0),n.set(t.name,o),s==="accessor"){let{name:r}=t;return{set(a){let l=e.get.call(this);e.set.call(this,a),this.requestUpdate(r,l,o,!0,a)},init(a){return a!==void 0&&this.C(r,void 0,o,a),a}}}if(s==="setter"){let{name:r}=t;return function(a){let l=this[r];e.call(this,a),this.requestUpdate(r,l,o,!0,a)}}throw Error("Unsupported decorator location: "+s)};function v(o){return(e,t)=>typeof t=="object"?et(o,e,t):((s,i,n)=>{let r=i.hasOwnProperty(n);return i.constructor.createProperty(n,s),r?Object.getOwnPropertyDescriptor(i,n):void 0})(o,e,t)}function m(o){return v({...o,state:!0,attribute:!1})}var Ne=["dimmer","rgb","rgbw","rgbww","color_temp","xy","binary","fixed"],Ae=["artnet-direct","artnet-controller","sacn","kinet"],Ce=["8bit","16bit","24bit","32bit"],X=["linear","quadratic","cubic","quadruple"],tt={fixed:[255],binary:null,dimmer:null,color_temp:"ch",rgb:"rgb",rgbw:"rgbw",rgbww:"rgbch",xy:"dxy"},st={"8bit":1,"16bit":2,"24bit":3,"32bit":4};function it(o){if(o.type==="binary"||o.type==="dimmer")return 1;let e=(o.channel_setup&&o.channel_setup.length?o.channel_setup:null)??tt[o.type];return e?e.length:1}function Z(o){let e=it(o),t=st[o.channel_size??"8bit"]??1,s=o.channel;return[s,s+e*t-1]}function Pe(o){return o.node_type==="artnet-controller"?"artnet-controller":`${o.node_type}:${o.host}:${o.port??"default"}`}function ce(){return crypto.randomUUID?crypto.randomUUID():String(Math.random()).slice(2)}function Te(o){return`hsl(${o*137.5%360}, 45%, 45%)`}var Ue=o=>o.callWS({type:"artnet_led/patch/get"});var Me=(o,e)=>o.callWS({type:"artnet_led/patch/save",patch:e});var He=(o,e,t,s)=>o.connection.subscribeMessage(s,{type:"artnet_led/dmx/subscribe",node_key:e,universe:t});var De=k`
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+  }
+  .dialog {
+    background: var(--card-background-color, #fff);
+    color: var(--primary-text-color, #212121);
+    border-radius: 12px;
+    padding: 20px 24px;
+    width: min(440px, calc(100vw - 32px));
+    max-height: calc(100vh - 64px);
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  }
+  h3 {
+    margin: 0 0 16px;
+    font-size: 1.15rem;
+  }
+  label {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--secondary-text-color, #727272);
+    margin: 12px 0 4px;
+  }
+  input,
+  select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--divider-color, #e0e0e0);
+    background: var(--secondary-background-color, #fafafa);
+    color: var(--primary-text-color, #212121);
+    font: inherit;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 20px;
+  }
+  .actions .spacer {
+    flex: 1;
+  }
+  button {
+    font: inherit;
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    background: var(--secondary-background-color, #f0f0f0);
+    color: var(--primary-text-color, #212121);
+  }
+  button.primary {
+    background: var(--primary-color, #03a9f4);
+    color: var(--text-primary-color, #fff);
+  }
+  button.danger {
+    background: var(--error-color, #db4437);
+    color: #fff;
+  }
+  .error {
+    color: var(--error-color, #db4437);
+    font-size: 0.85rem;
+    margin-top: 8px;
+  }
+  .hint {
+    font-size: 0.75rem;
+    color: var(--secondary-text-color, #727272);
+    margin-top: 4px;
+  }
+`,x=class extends g{constructor(){super(...arguments);this.isNew=!1;this.errorText=""}willUpdate(t){t.has("device")&&(this._working={...this.device})}_set(t,s){this._working={...this._working,[t]:s}}render(){let t=this._working,[s,i]=Z(t),n=t.type==="color_temp"||t.type==="rgbww";return d`
+      <div class="backdrop" @click=${this._backdropClick}>
+        <div class="dialog" @click=${r=>r.stopPropagation()}>
+          <h3>${this.isNew?"Add fixture":`Edit ${this.device.name}`}</h3>
+
+          <label>Name (entity id becomes light.&lt;slug&gt;)</label>
+          <input
+            .value=${t.name??""}
+            @input=${r=>this._set("name",r.target.value)}
+          />
+
+          <label>Friendly name (optional)</label>
+          <input
+            .value=${t.friendly_name??""}
+            @input=${r=>this._set("friendly_name",r.target.value||void 0)}
+          />
+
+          <div class="row">
+            <div>
+              <label>Type</label>
+              <select
+                .value=${t.type}
+                @change=${r=>this._set("type",r.target.value)}
+              >
+                ${Ne.map(r=>d`<option value=${r} ?selected=${t.type===r}>${r}</option>`)}
+              </select>
+            </div>
+            <div>
+              <label>DMX channel (1-512)</label>
+              <input
+                type="number"
+                min="1"
+                max="512"
+                .value=${String(t.channel)}
+                @input=${r=>this._set("channel",Number(r.target.value))}
+              />
+            </div>
+          </div>
+          <div class="hint">Occupies channels ${s}–${i}</div>
+
+          <div class="row">
+            <div>
+              <label>Channel size</label>
+              <select
+                .value=${t.channel_size??"8bit"}
+                @change=${r=>this._set("channel_size",r.target.value)}
+              >
+                ${Ce.map(r=>d`<option value=${r} ?selected=${(t.channel_size??"8bit")===r}>${r}</option>`)}
+              </select>
+            </div>
+            <div>
+              <label>Byte order</label>
+              <select
+                .value=${t.byte_order??"big"}
+                @change=${r=>this._set("byte_order",r.target.value)}
+              >
+                <option value="big" ?selected=${(t.byte_order??"big")==="big"}>big</option>
+                <option value="little" ?selected=${t.byte_order==="little"}>little</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="row">
+            <div>
+              <label>Transition (s)</label>
+              <input
+                type="number"
+                min="0"
+                max="999"
+                step="0.1"
+                .value=${String(t.transition??0)}
+                @input=${r=>this._set("transition",Number(r.target.value))}
+              />
+            </div>
+            <div>
+              <label>Output correction</label>
+              <select
+                @change=${r=>{let a=r.target.value;this._set("output_correction",a===""?null:a)}}
+              >
+                <option value="" ?selected=${!t.output_correction}>universe default</option>
+                ${X.map(r=>d`<option value=${r} ?selected=${t.output_correction===r}>${r}</option>`)}
+              </select>
+            </div>
+          </div>
+
+          <label>Channel setup (optional, e.g. rgbw / dCH)</label>
+          <input
+            .value=${typeof t.channel_setup=="string"?t.channel_setup:""}
+            placeholder="type default"
+            @input=${r=>this._set("channel_setup",r.target.value||null)}
+          />
+
+          ${n?d`
+                <div class="row">
+                  <div>
+                    <label>Min temp</label>
+                    <input
+                      .value=${t.min_temp??"2700K"}
+                      @input=${r=>this._set("min_temp",r.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label>Max temp</label>
+                    <input
+                      .value=${t.max_temp??"6500K"}
+                      @input=${r=>this._set("max_temp",r.target.value)}
+                    />
+                  </div>
+                </div>
+              `:c}
+
+          ${this.errorText?d`<div class="error">${this.errorText}</div>`:c}
+
+          <div class="actions">
+            ${this.isNew?c:d`<button class="danger" @click=${this._delete}>Delete</button>`}
+            <span class="spacer"></span>
+            <button @click=${this._cancel}>Cancel</button>
+            <button class="primary" @click=${this._save}>
+              ${this.isNew?"Add":"Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    `}_backdropClick(){this._cancel()}_cancel(){this.dispatchEvent(new CustomEvent("dialog-closed",{bubbles:!0,composed:!0}))}_save(){if(!this._working.name?.trim()){this.errorText="Name is required";return}this.dispatchEvent(new CustomEvent("save-device",{detail:{device:this._working,original:this.device},bubbles:!0,composed:!0}))}_delete(){this.dispatchEvent(new CustomEvent("delete-device",{detail:{device:this.device},bubbles:!0,composed:!0}))}};x.styles=De,h([v({attribute:!1})],x.prototype,"device",2),h([v({type:Boolean})],x.prototype,"isNew",2),h([v()],x.prototype,"errorText",2),h([m()],x.prototype,"_working",2),x=h([T("artnet-device-dialog")],x);var E=class extends g{constructor(){super(...arguments);this.isNew=!1;this.errorText=""}willUpdate(t){t.has("node")&&(this._working={...this.node})}_set(t,s){this._working={...this._working,[t]:s}}render(){let t=this._working;return d`
+      <div class="backdrop" @click=${this._cancel}>
+        <div class="dialog" @click=${s=>s.stopPropagation()}>
+          <h3>${this.isNew?"Add node":`Edit ${this.node.host}`}</h3>
+
+          <label>Protocol</label>
+          <select
+            @change=${s=>this._set("node_type",s.target.value)}
+          >
+            ${Ae.map(s=>d`<option value=${s} ?selected=${t.node_type===s}>${s}</option>`)}
+          </select>
+          ${t.node_type==="artnet-controller"?d`<div class="hint">
+                Controller mode discovers nodes and accepts DMX input. Only one controller can
+                exist (it binds UDP 6454).
+              </div>`:c}
+
+          <label>Host (IP of the Art-Net node)</label>
+          <input
+            .value=${t.host??""}
+            @input=${s=>this._set("host",s.target.value)}
+          />
+
+          <div class="row">
+            <div>
+              <label>Port (blank = protocol default)</label>
+              <input
+                type="number"
+                .value=${t.port!=null?String(t.port):""}
+                @input=${s=>{let i=s.target.value;this._set("port",i===""?null:Number(i))}}
+              />
+            </div>
+            <div>
+              <label>Max FPS (1-50)</label>
+              <input
+                type="number"
+                min="1"
+                max="50"
+                .value=${String(t.max_fps??25)}
+                @input=${s=>this._set("max_fps",Number(s.target.value))}
+              />
+            </div>
+          </div>
+
+          <div class="row">
+            <div>
+              <label>Refresh every (s, 0 = off)</label>
+              <input
+                type="number"
+                min="0"
+                max="9999"
+                .value=${String(t.refresh_every??120)}
+                @input=${s=>this._set("refresh_every",Number(s.target.value))}
+              />
+            </div>
+            <div>
+              <label>Host override (optional)</label>
+              <input
+                .value=${t.host_override??""}
+                @input=${s=>this._set("host_override",s.target.value||void 0)}
+              />
+            </div>
+          </div>
+
+          ${this.errorText?d`<div class="error">${this.errorText}</div>`:c}
+
+          <div class="actions">
+            ${this.isNew?c:d`<button class="danger" @click=${this._delete}>Delete node</button>`}
+            <span class="spacer"></span>
+            <button @click=${this._cancel}>Cancel</button>
+            <button class="primary" @click=${this._save}>
+              ${this.isNew?"Add":"Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    `}_cancel(){this.dispatchEvent(new CustomEvent("dialog-closed",{bubbles:!0,composed:!0}))}_save(){if(!this._working.host?.trim()){this.errorText="Host is required";return}this.dispatchEvent(new CustomEvent("save-node",{detail:{node:this._working,original:this.node},bubbles:!0,composed:!0}))}_delete(){this.dispatchEvent(new CustomEvent("delete-node",{detail:{node:this.node},bubbles:!0,composed:!0}))}};E.styles=De,h([v({attribute:!1})],E.prototype,"node",2),h([v({type:Boolean})],E.prototype,"isNew",2),h([v()],E.prototype,"errorText",2),h([m()],E.prototype,"_working",2),E=h([T("artnet-node-dialog")],E);function Oe(o){return{id:ce(),channel:o,name:"",type:"dimmer",transition:0,channel_size:"8bit",byte_order:"big",output_correction:null,channel_setup:null}}function Re(){return{id:ce(),node_type:"artnet-direct",host:"",port:null,max_fps:25,refresh_every:120,universes:{0:{send_partial_universe:!0,output_correction:"linear",devices:[]}}}}var b=class extends g{constructor(){super(...arguments);this.nodeKey="";this.universeNr=0;this.readonly=!1;this._live=!1;this._values=[]}disconnectedCallback(){super.disconnectedCallback(),this._stopLive()}async _toggleLive(){if(this._live){this._stopLive(),this._live=!1;return}this._live=!0;try{this._unsub=await He(this.hass,this.nodeKey,this.universeNr,t=>{this._values=t.values})}catch(t){this._live=!1,this.dispatchEvent(new CustomEvent("grid-error",{detail:`Live monitoring unavailable: ${t}`,bubbles:!0,composed:!0}))}}_stopLive(){this._unsub?.(),this._unsub=void 0,this._values=[]}_channelMap(){let t=new Map;return(this.universe?.devices??[]).forEach((s,i)=>{let[n,r]=Z(s);for(let a=n;a<=Math.min(r,512);a++){let l=t.get(a);t.set(a,{device:s,index:i,first:a===n,overlap:!!l})}}),t}render(){let t=this._channelMap(),s=[];for(let i=1;i<=512;i++){let n=t.get(i),r=this._values[i-1],a=this._live&&r!==void 0?r/255:0;s.push(d`
+        <div
+          class="cell ${n?"occupied":""} ${n?.overlap?"overlap":""}"
+          style=${n?`--device-color: ${Te(n.index)}`:c}
+          title=${n?`${n.device.name} (${n.device.type}) \u2014 channel ${i}`:`Channel ${i}`}
+          @click=${()=>this._cellClick(i,n?.device)}
+        >
+          ${this._live?d`<span class="heat" style="opacity: ${a}"></span>`:c}
+          <span class="ch">${i}</span>
+          ${n?.first?d`<span class="name">${n.device.name}</span>`:c}
+          ${this._live&&r!==void 0?d`<span class="val">${r}</span>`:c}
+        </div>
+      `)}return d`
+      <div class="toolbar">
+        <label class="live-toggle">
+          <input
+            type="checkbox"
+            .checked=${this._live}
+            @change=${this._toggleLive}
+          />
+          Live DMX values
+        </label>
+        ${this.readonly?d`<span class="readonly-hint">YAML-configured (read-only)</span>`:c}
+      </div>
+      <div class="grid">${s}</div>
+    `}_cellClick(t,s){this.readonly||(s?this.dispatchEvent(new CustomEvent("edit-device",{detail:{device:s},bubbles:!0,composed:!0})):this.dispatchEvent(new CustomEvent("add-device",{detail:{channel:t},bubbles:!0,composed:!0})))}};b.styles=k`
+    :host {
+      display: block;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 8px;
+    }
+    .live-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.9rem;
+      color: var(--primary-text-color);
+      cursor: pointer;
+    }
+    .readonly-hint {
+      font-size: 0.85rem;
+      color: var(--secondary-text-color);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+      gap: 2px;
+    }
+    .cell {
+      position: relative;
+      aspect-ratio: 1;
+      min-width: 0;
+      border-radius: 4px;
+      background: var(--secondary-background-color, #f0f0f0);
+      cursor: pointer;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 3px 4px;
+      box-sizing: border-box;
+      border: 1px solid transparent;
+    }
+    .cell:hover {
+      border-color: var(--primary-color);
+    }
+    .cell.occupied {
+      background: var(--device-color);
+      color: #fff;
+    }
+    .cell.overlap {
+      outline: 2px solid var(--error-color, #db4437);
+      outline-offset: -2px;
+    }
+    .heat {
+      position: absolute;
+      inset: 0;
+      background: var(--primary-color, #03a9f4);
+      pointer-events: none;
+    }
+    .cell.occupied .heat {
+      background: #fff;
+      mix-blend-mode: overlay;
+    }
+    .ch {
+      position: relative;
+      font-size: 0.6rem;
+      opacity: 0.7;
+      line-height: 1;
+    }
+    .name {
+      position: relative;
+      font-size: 0.62rem;
+      font-weight: 600;
+      line-height: 1.1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      word-break: break-all;
+    }
+    .val {
+      position: relative;
+      font-size: 0.65rem;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+  `,h([v({attribute:!1})],b.prototype,"hass",2),h([v({attribute:!1})],b.prototype,"universe",2),h([v()],b.prototype,"nodeKey",2),h([v({type:Number})],b.prototype,"universeNr",2),h([v({type:Boolean})],b.prototype,"readonly",2),h([m()],b.prototype,"_live",2),h([m()],b.prototype,"_values",2),b=h([T("artnet-universe-grid")],b);var _=class extends g{constructor(){super(...arguments);this.narrow=!1;this._patch={nodes:[]};this._yamlNodes=[];this._loaded=!1;this._dirty=!1;this._saving=!1;this._errors=[];this._toast="";this._selected="";this._selectedUniverse="";this._dialog={kind:"none"};this._beforeUnload=t=>{this._dirty&&t.preventDefault()}}connectedCallback(){super.connectedCallback(),this._load(),window.addEventListener("beforeunload",this._beforeUnload)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("beforeunload",this._beforeUnload)}async _load(){try{let t=await Ue(this.hass);this._patch=t.patch??{nodes:[]},this._yamlNodes=t.yaml_nodes??[],this._loaded=!0,this._autoSelect()}catch(t){this._showToast(`Failed to load patch: ${t}`)}}_autoSelect(){this._selected||(this._patch.nodes.length?this._selectNode("ui:0"):this._yamlNodes.length&&this._selectNode("yaml:0"))}_selectNode(t){this._selected=t;let s=this._currentUniverses(),i=Object.keys(s??{}).sort((n,r)=>Number(n)-Number(r));this._selectedUniverse=i[0]??""}_currentNode(){let[t,s]=this._selected.split(":"),i=Number(s);if(t==="ui")return this._patch.nodes[i];if(t==="yaml")return this._yamlNodes[i]}_isYamlSelected(){return this._selected.startsWith("yaml:")}_currentUniverses(){return this._currentNode()?.universes}_markDirty(){this._dirty=!0,this._patch={...this._patch,nodes:[...this._patch.nodes]}}async _save(){this._saving=!0,this._errors=[];try{let t=await Me(this.hass,this._patch);t.success?(this._dirty=!1,this._showToast("Patch saved \u2014 changes applied live")):(this._errors=t.errors,this._showToast("Patch has errors; nothing was saved"))}catch(t){this._showToast(`Save failed: ${t}`)}finally{this._saving=!1}}_showToast(t){this._toast=t,clearTimeout(this._toastTimer),this._toastTimer=window.setTimeout(()=>this._toast="",4e3)}_addNode(){this._dialog={kind:"node",node:Re(),isNew:!0}}_editNode(){let t=this._currentNode();!t||this._isYamlSelected()||(this._dialog={kind:"node",node:t,isNew:!1})}_onSaveNode(t){let{node:s,original:i}=t.detail,n=this._patch.nodes,r=n.findIndex(a=>a.id===i.id);r>=0?n[r]=s:(n.push(s),this._selectNode(`ui:${n.length-1}`)),this._dialog={kind:"none"},this._markDirty()}_onDeleteNode(t){let{node:s}=t.detail;this._patch.nodes=this._patch.nodes.filter(i=>i.id!==s.id),this._dialog={kind:"none"},this._selected="",this._autoSelect(),this._markDirty()}_addUniverse(){if(this._isYamlSelected())return;let t=this._currentNode();if(!t)return;let s=prompt("Universe number (0-1024):","0");if(s===null)return;let i=String(Number(s));if(Number.isNaN(Number(s))||Number(i)<0||Number(i)>1024){this._showToast("Universe must be a number between 0 and 1024");return}if(t.universes[i]){this._showToast(`Universe ${i} already exists`);return}t.universes={...t.universes,[i]:{send_partial_universe:!0,output_correction:"linear",devices:[]}},this._selectedUniverse=i,this._markDirty()}_removeUniverse(){if(this._isYamlSelected())return;let t=this._currentNode();if(!t||!this._selectedUniverse)return;let s=t.universes[this._selectedUniverse]?.devices??[];if(s.length&&!confirm(`Delete universe ${this._selectedUniverse} and its ${s.length} fixture(s)?`))return;let i={...t.universes};delete i[this._selectedUniverse],t.universes=i;let n=Object.keys(i).sort((r,a)=>Number(r)-Number(a));this._selectedUniverse=n[0]??"",this._markDirty()}_setUniverseOption(t,s){if(this._isYamlSelected())return;let n=this._currentNode()?.universes[this._selectedUniverse];n&&(n[t]=s,this._markDirty())}_onAddDevice(t){this._isYamlSelected()||(this._dialog={kind:"device",device:Oe(t.detail.channel),isNew:!0,universeNr:this._selectedUniverse})}_onEditDevice(t){this._isYamlSelected()||(this._dialog={kind:"device",device:t.detail.device,isNew:!1,universeNr:this._selectedUniverse})}_onSaveDevice(t){let{device:s,original:i}=t.detail;if(this._dialog.kind!=="device")return;let r=this._currentNode()?.universes[this._dialog.universeNr];if(!r)return;let a=r.devices.findIndex(l=>l.id===i.id);a>=0?r.devices[a]=s:r.devices.push(s),r.devices=[...r.devices],this._dialog={kind:"none"},this._markDirty()}_onDeleteDevice(t){let{device:s}=t.detail;if(this._dialog.kind!=="device")return;let n=this._currentNode()?.universes[this._dialog.universeNr];n&&(n.devices=n.devices.filter(r=>r.id!==s.id),this._dialog={kind:"none"},this._markDirty())}render(){if(!this._loaded)return d`<div class="loading">Loading DMX patch…</div>`;let t=this._currentNode(),s=this._isYamlSelected(),i=this._currentUniverses()??{},n=Object.keys(i).sort((a,l)=>Number(a)-Number(l)),r=i[this._selectedUniverse];return d`
+      <div class="header">
+        <h1>DMX Patch</h1>
+        ${this._dirty?d`<span class="dirty">unsaved changes</span>`:c}
+        <span class="spacer"></span>
+        <button
+          class="primary"
+          ?disabled=${!this._dirty||this._saving}
+          @click=${this._save}
+        >
+          ${this._saving?"Saving\u2026":"Save & Apply"}
+        </button>
+      </div>
+
+      <div class="layout ${this.narrow?"narrow":""}">
+        <nav class="rail">
+          <div class="rail-section">Patch nodes</div>
+          ${this._patch.nodes.map((a,l)=>d`
+              <button
+                class="rail-item ${this._selected===`ui:${l}`?"active":""}"
+                @click=${()=>this._selectNode(`ui:${l}`)}
+              >
+                <span class="rail-title">${a.host||"(new node)"}</span>
+                <span class="rail-sub">${a.node_type}</span>
+              </button>
+            `)}
+          <button class="rail-add" @click=${this._addNode}>+ Add node</button>
+
+          ${this._yamlNodes.length?d`
+                <div class="rail-section">YAML nodes 🔒</div>
+                ${this._yamlNodes.map((a,l)=>d`
+                    <button
+                      class="rail-item ${this._selected===`yaml:${l}`?"active":""}"
+                      @click=${()=>this._selectNode(`yaml:${l}`)}
+                    >
+                      <span class="rail-title">${a.host}</span>
+                      <span class="rail-sub">${a.node_type} · read-only</span>
+                    </button>
+                  `)}
+              `:c}
+        </nav>
+
+        <main class="main">
+          ${t?d`
+                <div class="node-bar">
+                  <h2>${t.host} <small>(${t.node_type})</small></h2>
+                  ${s?c:d`<button @click=${this._editNode}>Node settings</button>`}
+                </div>
+
+                <div class="universe-bar">
+                  ${n.map(a=>d`
+                      <button
+                        class="tab ${this._selectedUniverse===a?"active":""}"
+                        @click=${()=>this._selectedUniverse=a}
+                      >
+                        Universe ${a}
+                      </button>
+                    `)}
+                  ${s?c:d`
+                        <button class="tab add" @click=${this._addUniverse}>+</button>
+                        ${this._selectedUniverse?d`<button class="tab remove" @click=${this._removeUniverse}>
+                              Remove universe
+                            </button>`:c}
+                      `}
+                </div>
+
+                ${r?d`
+                      <div class="universe-options">
+                        <label>
+                          Output correction
+                          <select
+                            ?disabled=${s}
+                            @change=${a=>this._setUniverseOption("output_correction",a.target.value)}
+                          >
+                            ${X.map(a=>d`<option
+                                  value=${a}
+                                  ?selected=${(r.output_correction??"linear")===a}
+                                >
+                                  ${a}
+                                </option>`)}
+                          </select>
+                        </label>
+                        <label>
+                          <input
+                            type="checkbox"
+                            ?disabled=${s}
+                            .checked=${r.send_partial_universe??!0}
+                            @change=${a=>this._setUniverseOption("send_partial_universe",a.target.checked)}
+                          />
+                          Send partial universe
+                        </label>
+                      </div>
+
+                      <artnet-universe-grid
+                        .hass=${this.hass}
+                        .universe=${r}
+                        .universeNr=${Number(this._selectedUniverse)}
+                        .nodeKey=${Pe(t)}
+                        ?readonly=${s}
+                        @add-device=${this._onAddDevice}
+                        @edit-device=${this._onEditDevice}
+                        @grid-error=${a=>this._showToast(a.detail)}
+                      ></artnet-universe-grid>
+                    `:d`<div class="empty">No universes. Add one to start placing fixtures.</div>`}
+              `:d`<div class="empty">
+                No nodes yet. Add a node to start patching, or configure one in YAML.
+              </div>`}
+
+          ${this._errors.length?d`
+                <div class="errors">
+                  <strong>Validation errors</strong>
+                  <ul>
+                    ${this._errors.map(a=>d`<li><code>${a.path}</code>: ${a.message}</li>`)}
+                  </ul>
+                </div>
+              `:c}
+        </main>
+      </div>
+
+      ${this._dialog.kind==="device"?d`
+            <artnet-device-dialog
+              .device=${this._dialog.device}
+              ?isNew=${this._dialog.isNew}
+              @dialog-closed=${()=>this._dialog={kind:"none"}}
+              @save-device=${this._onSaveDevice}
+              @delete-device=${this._onDeleteDevice}
+            ></artnet-device-dialog>
+          `:c}
+      ${this._dialog.kind==="node"?d`
+            <artnet-node-dialog
+              .node=${this._dialog.node}
+              ?isNew=${this._dialog.isNew}
+              @dialog-closed=${()=>this._dialog={kind:"none"}}
+              @save-node=${this._onSaveNode}
+              @delete-node=${this._onDeleteNode}
+            ></artnet-node-dialog>
+          `:c}
+      ${this._toast?d`<div class="toast">${this._toast}</div>`:c}
+    `}};_.styles=k`
+    :host {
+      display: block;
+      height: 100%;
+      background: var(--primary-background-color);
+      color: var(--primary-text-color);
+      font-family: var(--paper-font-body1_-_font-family, Roboto, sans-serif);
+    }
+    .loading,
+    .empty {
+      padding: 32px;
+      color: var(--secondary-text-color);
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 16px;
+      background: var(--app-header-background-color, var(--primary-color));
+      color: var(--app-header-text-color, #fff);
+    }
+    .header h1 {
+      font-size: 1.25rem;
+      font-weight: 400;
+      margin: 0;
+    }
+    .dirty {
+      font-size: 0.8rem;
+      opacity: 0.85;
+      font-style: italic;
+    }
+    .spacer {
+      flex: 1;
+    }
+    button {
+      font: inherit;
+      padding: 8px 14px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      background: var(--secondary-background-color, #f0f0f0);
+      color: var(--primary-text-color, #212121);
+    }
+    button.primary {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+    }
+    button.primary:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    .layout {
+      display: flex;
+      height: calc(100% - 56px);
+    }
+    .layout.narrow {
+      flex-direction: column;
+    }
+    .rail {
+      width: 220px;
+      flex-shrink: 0;
+      border-right: 1px solid var(--divider-color, #e0e0e0);
+      padding: 12px 8px;
+      box-sizing: border-box;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .narrow .rail {
+      width: 100%;
+      border-right: none;
+      border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+    .rail-section {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--secondary-text-color);
+      margin: 8px 8px 4px;
+    }
+    .rail-item {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      text-align: left;
+      background: none;
+      border-radius: 8px;
+      padding: 8px 10px;
+    }
+    .rail-item.active {
+      background: var(--secondary-background-color, #f0f0f0);
+    }
+    .rail-title {
+      font-weight: 500;
+    }
+    .rail-sub {
+      font-size: 0.75rem;
+      color: var(--secondary-text-color);
+    }
+    .rail-add {
+      background: none;
+      color: var(--primary-color);
+      text-align: left;
+      padding: 8px 10px;
+    }
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+      box-sizing: border-box;
+    }
+    .node-bar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+    .node-bar h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+    .node-bar small {
+      color: var(--secondary-text-color);
+      font-weight: 400;
+    }
+    .universe-bar {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin-bottom: 10px;
+    }
+    .tab {
+      border-radius: 16px;
+      padding: 6px 14px;
+    }
+    .tab.active {
+      background: var(--primary-color);
+      color: var(--text-primary-color, #fff);
+    }
+    .tab.add {
+      font-weight: 700;
+    }
+    .tab.remove {
+      color: var(--error-color, #db4437);
+      background: none;
+    }
+    .universe-options {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      margin-bottom: 12px;
+      font-size: 0.9rem;
+    }
+    .universe-options label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .universe-options select {
+      font: inherit;
+      padding: 4px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--divider-color, #e0e0e0);
+      background: var(--secondary-background-color, #fafafa);
+      color: var(--primary-text-color);
+    }
+    .errors {
+      margin-top: 16px;
+      padding: 12px 16px;
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--error-color, #db4437) 12%, transparent);
+      border: 1px solid var(--error-color, #db4437);
+      font-size: 0.9rem;
+    }
+    .errors ul {
+      margin: 8px 0 0;
+      padding-left: 20px;
+    }
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--primary-text-color);
+      color: var(--primary-background-color);
+      padding: 10px 20px;
+      border-radius: 24px;
+      font-size: 0.9rem;
+      z-index: 20;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    }
+  `,h([v({attribute:!1})],_.prototype,"hass",2),h([v({type:Boolean})],_.prototype,"narrow",2),h([m()],_.prototype,"_patch",2),h([m()],_.prototype,"_yamlNodes",2),h([m()],_.prototype,"_loaded",2),h([m()],_.prototype,"_dirty",2),h([m()],_.prototype,"_saving",2),h([m()],_.prototype,"_errors",2),h([m()],_.prototype,"_toast",2),h([m()],_.prototype,"_selected",2),h([m()],_.prototype,"_selectedUniverse",2),h([m()],_.prototype,"_dialog",2),_=h([T("artnet-patch-panel")],_);export{_ as ArtnetPatchPanel};
+/*! Bundled license information:
+
+@lit/reactive-element/css-tag.js:
+  (**
+   * @license
+   * Copyright 2019 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/reactive-element.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+lit-html/lit-html.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+lit-element/lit-element.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+lit-html/is-server.js:
+  (**
+   * @license
+   * Copyright 2022 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/custom-element.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/property.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/state.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/event-options.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/base.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/query.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/query-all.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/query-async.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/query-assigned-elements.js:
+  (**
+   * @license
+   * Copyright 2021 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+
+@lit/reactive-element/decorators/query-assigned-nodes.js:
+  (**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   *)
+*/

--- a/custom_components/artnet_led/frontend/package.json
+++ b/custom_components/artnet_led/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ha-artnet-led-panel",
+  "version": "0.2.0",
+  "private": true,
+  "description": "DMX Patch panel for the ha-artnet-led Home Assistant integration",
+  "scripts": {
+    "build": "esbuild src/panel.ts --bundle --format=esm --minify --outfile=dist/panel.js",
+    "watch": "esbuild src/panel.ts --bundle --format=esm --outfile=dist/panel.js --watch"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "lit": "^3.2.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/custom_components/artnet_led/frontend/src/dialogs.ts
+++ b/custom_components/artnet_led/frontend/src/dialogs.ts
@@ -1,0 +1,470 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  PatchDevice,
+  PatchNode,
+  DEVICE_TYPES,
+  NODE_TYPES,
+  CHANNEL_SIZES,
+  CORRECTIONS,
+  footprint,
+  uuid,
+} from './model';
+
+const sharedDialogStyles = css`
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+  }
+  .dialog {
+    background: var(--card-background-color, #fff);
+    color: var(--primary-text-color, #212121);
+    border-radius: 12px;
+    padding: 20px 24px;
+    width: min(440px, calc(100vw - 32px));
+    max-height: calc(100vh - 64px);
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  }
+  h3 {
+    margin: 0 0 16px;
+    font-size: 1.15rem;
+  }
+  label {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--secondary-text-color, #727272);
+    margin: 12px 0 4px;
+  }
+  input,
+  select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--divider-color, #e0e0e0);
+    background: var(--secondary-background-color, #fafafa);
+    color: var(--primary-text-color, #212121);
+    font: inherit;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 20px;
+  }
+  .actions .spacer {
+    flex: 1;
+  }
+  button {
+    font: inherit;
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    background: var(--secondary-background-color, #f0f0f0);
+    color: var(--primary-text-color, #212121);
+  }
+  button.primary {
+    background: var(--primary-color, #03a9f4);
+    color: var(--text-primary-color, #fff);
+  }
+  button.danger {
+    background: var(--error-color, #db4437);
+    color: #fff;
+  }
+  .error {
+    color: var(--error-color, #db4437);
+    font-size: 0.85rem;
+    margin-top: 8px;
+  }
+  .hint {
+    font-size: 0.75rem;
+    color: var(--secondary-text-color, #727272);
+    margin-top: 4px;
+  }
+`;
+
+/** Add/edit one fixture. Fires 'save-device' {device, original} or 'delete-device' {device}. */
+@customElement('artnet-device-dialog')
+export class ArtnetDeviceDialog extends LitElement {
+  /** Device being edited, or a template for a new one. */
+  @property({ attribute: false }) device!: PatchDevice;
+  @property({ type: Boolean }) isNew = false;
+  @property() errorText = '';
+
+  @state() private _working!: PatchDevice;
+
+  willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('device')) {
+      this._working = { ...this.device };
+    }
+  }
+
+  private _set<K extends keyof PatchDevice>(key: K, value: PatchDevice[K]) {
+    this._working = { ...this._working, [key]: value };
+  }
+
+  render() {
+    const d = this._working;
+    const [first, last] = footprint(d);
+    const showTemp = d.type === 'color_temp' || d.type === 'rgbww';
+
+    return html`
+      <div class="backdrop" @click=${this._backdropClick}>
+        <div class="dialog" @click=${(e: Event) => e.stopPropagation()}>
+          <h3>${this.isNew ? 'Add fixture' : `Edit ${this.device.name}`}</h3>
+
+          <label>Name (entity id becomes light.&lt;slug&gt;)</label>
+          <input
+            .value=${d.name ?? ''}
+            @input=${(e: Event) => this._set('name', (e.target as HTMLInputElement).value)}
+          />
+
+          <label>Friendly name (optional)</label>
+          <input
+            .value=${d.friendly_name ?? ''}
+            @input=${(e: Event) =>
+              this._set('friendly_name', (e.target as HTMLInputElement).value || undefined)}
+          />
+
+          <div class="row">
+            <div>
+              <label>Type</label>
+              <select
+                .value=${d.type}
+                @change=${(e: Event) => this._set('type', (e.target as HTMLSelectElement).value)}
+              >
+                ${DEVICE_TYPES.map((t) => html`<option value=${t} ?selected=${d.type === t}>${t}</option>`)}
+              </select>
+            </div>
+            <div>
+              <label>DMX channel (1-512)</label>
+              <input
+                type="number"
+                min="1"
+                max="512"
+                .value=${String(d.channel)}
+                @input=${(e: Event) =>
+                  this._set('channel', Number((e.target as HTMLInputElement).value))}
+              />
+            </div>
+          </div>
+          <div class="hint">Occupies channels ${first}–${last}</div>
+
+          <div class="row">
+            <div>
+              <label>Channel size</label>
+              <select
+                .value=${d.channel_size ?? '8bit'}
+                @change=${(e: Event) =>
+                  this._set('channel_size', (e.target as HTMLSelectElement).value)}
+              >
+                ${CHANNEL_SIZES.map(
+                  (s) => html`<option value=${s} ?selected=${(d.channel_size ?? '8bit') === s}>${s}</option>`
+                )}
+              </select>
+            </div>
+            <div>
+              <label>Byte order</label>
+              <select
+                .value=${d.byte_order ?? 'big'}
+                @change=${(e: Event) =>
+                  this._set('byte_order', (e.target as HTMLSelectElement).value)}
+              >
+                <option value="big" ?selected=${(d.byte_order ?? 'big') === 'big'}>big</option>
+                <option value="little" ?selected=${d.byte_order === 'little'}>little</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="row">
+            <div>
+              <label>Transition (s)</label>
+              <input
+                type="number"
+                min="0"
+                max="999"
+                step="0.1"
+                .value=${String(d.transition ?? 0)}
+                @input=${(e: Event) =>
+                  this._set('transition', Number((e.target as HTMLInputElement).value))}
+              />
+            </div>
+            <div>
+              <label>Output correction</label>
+              <select
+                @change=${(e: Event) => {
+                  const v = (e.target as HTMLSelectElement).value;
+                  this._set('output_correction', v === '' ? null : v);
+                }}
+              >
+                <option value="" ?selected=${!d.output_correction}>universe default</option>
+                ${CORRECTIONS.map(
+                  (c) =>
+                    html`<option value=${c} ?selected=${d.output_correction === c}>${c}</option>`
+                )}
+              </select>
+            </div>
+          </div>
+
+          <label>Channel setup (optional, e.g. rgbw / dCH)</label>
+          <input
+            .value=${typeof d.channel_setup === 'string' ? d.channel_setup : ''}
+            placeholder="type default"
+            @input=${(e: Event) =>
+              this._set('channel_setup', (e.target as HTMLInputElement).value || null)}
+          />
+
+          ${showTemp
+            ? html`
+                <div class="row">
+                  <div>
+                    <label>Min temp</label>
+                    <input
+                      .value=${d.min_temp ?? '2700K'}
+                      @input=${(e: Event) =>
+                        this._set('min_temp', (e.target as HTMLInputElement).value)}
+                    />
+                  </div>
+                  <div>
+                    <label>Max temp</label>
+                    <input
+                      .value=${d.max_temp ?? '6500K'}
+                      @input=${(e: Event) =>
+                        this._set('max_temp', (e.target as HTMLInputElement).value)}
+                    />
+                  </div>
+                </div>
+              `
+            : nothing}
+
+          ${this.errorText ? html`<div class="error">${this.errorText}</div>` : nothing}
+
+          <div class="actions">
+            ${!this.isNew
+              ? html`<button class="danger" @click=${this._delete}>Delete</button>`
+              : nothing}
+            <span class="spacer"></span>
+            <button @click=${this._cancel}>Cancel</button>
+            <button class="primary" @click=${this._save}>
+              ${this.isNew ? 'Add' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _backdropClick() {
+    this._cancel();
+  }
+
+  private _cancel() {
+    this.dispatchEvent(new CustomEvent('dialog-closed', { bubbles: true, composed: true }));
+  }
+
+  private _save() {
+    if (!this._working.name?.trim()) {
+      this.errorText = 'Name is required';
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent('save-device', {
+        detail: { device: this._working, original: this.device },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _delete() {
+    this.dispatchEvent(
+      new CustomEvent('delete-device', {
+        detail: { device: this.device },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  static styles = sharedDialogStyles;
+}
+
+/** Add/edit a node. Fires 'save-node' {node, original} or 'delete-node' {node}. */
+@customElement('artnet-node-dialog')
+export class ArtnetNodeDialog extends LitElement {
+  @property({ attribute: false }) node!: PatchNode;
+  @property({ type: Boolean }) isNew = false;
+  @property() errorText = '';
+
+  @state() private _working!: PatchNode;
+
+  willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('node')) {
+      this._working = { ...this.node };
+    }
+  }
+
+  private _set<K extends keyof PatchNode>(key: K, value: PatchNode[K]) {
+    this._working = { ...this._working, [key]: value };
+  }
+
+  render() {
+    const n = this._working;
+    return html`
+      <div class="backdrop" @click=${this._cancel}>
+        <div class="dialog" @click=${(e: Event) => e.stopPropagation()}>
+          <h3>${this.isNew ? 'Add node' : `Edit ${this.node.host}`}</h3>
+
+          <label>Protocol</label>
+          <select
+            @change=${(e: Event) => this._set('node_type', (e.target as HTMLSelectElement).value)}
+          >
+            ${NODE_TYPES.map(
+              (t) => html`<option value=${t} ?selected=${n.node_type === t}>${t}</option>`
+            )}
+          </select>
+          ${n.node_type === 'artnet-controller'
+            ? html`<div class="hint">
+                Controller mode discovers nodes and accepts DMX input. Only one controller can
+                exist (it binds UDP 6454).
+              </div>`
+            : nothing}
+
+          <label>Host (IP of the Art-Net node)</label>
+          <input
+            .value=${n.host ?? ''}
+            @input=${(e: Event) => this._set('host', (e.target as HTMLInputElement).value)}
+          />
+
+          <div class="row">
+            <div>
+              <label>Port (blank = protocol default)</label>
+              <input
+                type="number"
+                .value=${n.port != null ? String(n.port) : ''}
+                @input=${(e: Event) => {
+                  const v = (e.target as HTMLInputElement).value;
+                  this._set('port', v === '' ? null : Number(v));
+                }}
+              />
+            </div>
+            <div>
+              <label>Max FPS (1-50)</label>
+              <input
+                type="number"
+                min="1"
+                max="50"
+                .value=${String(n.max_fps ?? 25)}
+                @input=${(e: Event) =>
+                  this._set('max_fps', Number((e.target as HTMLInputElement).value))}
+              />
+            </div>
+          </div>
+
+          <div class="row">
+            <div>
+              <label>Refresh every (s, 0 = off)</label>
+              <input
+                type="number"
+                min="0"
+                max="9999"
+                .value=${String(n.refresh_every ?? 120)}
+                @input=${(e: Event) =>
+                  this._set('refresh_every', Number((e.target as HTMLInputElement).value))}
+              />
+            </div>
+            <div>
+              <label>Host override (optional)</label>
+              <input
+                .value=${n.host_override ?? ''}
+                @input=${(e: Event) =>
+                  this._set('host_override', (e.target as HTMLInputElement).value || undefined)}
+              />
+            </div>
+          </div>
+
+          ${this.errorText ? html`<div class="error">${this.errorText}</div>` : nothing}
+
+          <div class="actions">
+            ${!this.isNew
+              ? html`<button class="danger" @click=${this._delete}>Delete node</button>`
+              : nothing}
+            <span class="spacer"></span>
+            <button @click=${this._cancel}>Cancel</button>
+            <button class="primary" @click=${this._save}>
+              ${this.isNew ? 'Add' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _cancel() {
+    this.dispatchEvent(new CustomEvent('dialog-closed', { bubbles: true, composed: true }));
+  }
+
+  private _save() {
+    if (!this._working.host?.trim()) {
+      this.errorText = 'Host is required';
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent('save-node', {
+        detail: { node: this._working, original: this.node },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _delete() {
+    this.dispatchEvent(
+      new CustomEvent('delete-node', {
+        detail: { node: this.node },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  static styles = sharedDialogStyles;
+}
+
+export function newDevice(channel: number): PatchDevice {
+  return {
+    id: uuid(),
+    channel,
+    name: '',
+    type: 'dimmer',
+    transition: 0,
+    channel_size: '8bit',
+    byte_order: 'big',
+    output_correction: null,
+    channel_setup: null,
+  };
+}
+
+export function newNode(): PatchNode {
+  return {
+    id: uuid(),
+    node_type: 'artnet-direct',
+    host: '',
+    port: null,
+    max_fps: 25,
+    refresh_every: 120,
+    universes: { '0': { send_partial_universe: true, output_correction: 'linear', devices: [] } },
+  };
+}

--- a/custom_components/artnet_led/frontend/src/model.ts
+++ b/custom_components/artnet_led/frontend/src/model.ts
@@ -1,0 +1,137 @@
+/** Shared types + patch math. Mirrors validation.py — keep the two in sync. */
+
+export interface PatchDevice {
+  id: string;
+  channel: number;
+  name: string;
+  friendly_name?: string;
+  type: string;
+  transition?: number;
+  channel_size?: string;
+  byte_order?: string;
+  output_correction?: string | null;
+  channel_setup?: string | number[] | null;
+  min_temp?: string;
+  max_temp?: string;
+}
+
+export interface PatchUniverse {
+  send_partial_universe?: boolean;
+  output_correction?: string;
+  devices: PatchDevice[];
+}
+
+export interface PatchNode {
+  id: string;
+  node_type: string;
+  host: string;
+  port?: number | null;
+  host_override?: string;
+  port_override?: number | null;
+  max_fps?: number;
+  refresh_every?: number;
+  universes: Record<string, PatchUniverse>;
+}
+
+export interface PatchDoc {
+  nodes: PatchNode[];
+}
+
+export interface YamlNodeSnapshot {
+  key: string;
+  owner: string;
+  node_type: string;
+  host: string;
+  port: number | null;
+  universes: Record<string, PatchUniverse>;
+}
+
+export interface PatchError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export interface HomeAssistant {
+  callWS<T>(msg: Record<string, unknown>): Promise<T>;
+  connection: {
+    subscribeMessage<T>(
+      callback: (result: T) => void,
+      msg: Record<string, unknown>
+    ): Promise<() => Promise<void>>;
+  };
+}
+
+export const DEVICE_TYPES = [
+  'dimmer',
+  'rgb',
+  'rgbw',
+  'rgbww',
+  'color_temp',
+  'xy',
+  'binary',
+  'fixed',
+];
+
+export const NODE_TYPES = ['artnet-direct', 'artnet-controller', 'sacn', 'kinet'];
+export const CHANNEL_SIZES = ['8bit', '16bit', '24bit', '32bit'];
+export const CORRECTIONS = ['linear', 'quadratic', 'cubic', 'quadruple'];
+
+/** Mirrors DEFAULT_CHANNEL_SETUP in validation.py. */
+const DEFAULT_SETUP: Record<string, string | number[] | null> = {
+  fixed: [255],
+  binary: null,
+  dimmer: null,
+  color_temp: 'ch',
+  rgb: 'rgb',
+  rgbw: 'rgbw',
+  rgbww: 'rgbch',
+  xy: 'dxy',
+};
+
+const BYTE_SIZE: Record<string, number> = {
+  '8bit': 1,
+  '16bit': 2,
+  '24bit': 3,
+  '32bit': 4,
+};
+
+export function channelWidth(device: PatchDevice): number {
+  if (device.type === 'binary' || device.type === 'dimmer') return 1;
+  const setup =
+    (device.channel_setup && (device.channel_setup as string | number[]).length
+      ? device.channel_setup
+      : null) ?? DEFAULT_SETUP[device.type];
+  return setup ? setup.length : 1;
+}
+
+/** Inclusive [first, last] DMX channels occupied by a device. */
+export function footprint(device: PatchDevice): [number, number] {
+  const width = channelWidth(device);
+  const byteSize = BYTE_SIZE[device.channel_size ?? '8bit'] ?? 1;
+  const first = device.channel;
+  return [first, first + width * byteSize - 1];
+}
+
+/** Mirrors node_key() in runtime.py. */
+export function nodeKey(node: { node_type: string; host: string; port?: number | null }): string {
+  if (node.node_type === 'artnet-controller') return 'artnet-controller';
+  return `${node.node_type}:${node.host}:${node.port ?? 'default'}`;
+}
+
+export function uuid(): string {
+  return crypto.randomUUID ? crypto.randomUUID() : String(Math.random()).slice(2);
+}
+
+/** Stable per-device accent color, spread around the hue wheel. */
+export function deviceColor(index: number): string {
+  const hue = (index * 137.5) % 360;
+  return `hsl(${hue}, 45%, 45%)`;
+}
+
+export function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}

--- a/custom_components/artnet_led/frontend/src/panel.ts
+++ b/custom_components/artnet_led/frontend/src/panel.ts
@@ -1,0 +1,647 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  HomeAssistant,
+  PatchDoc,
+  PatchDevice,
+  PatchNode,
+  PatchError,
+  PatchUniverse,
+  YamlNodeSnapshot,
+  CORRECTIONS,
+  nodeKey,
+} from './model';
+import { getPatch, savePatch } from './ws';
+import { newDevice, newNode } from './dialogs';
+import './universe-grid';
+import './dialogs';
+
+type DialogState =
+  | { kind: 'none' }
+  | { kind: 'device'; device: PatchDevice; isNew: boolean; universeNr: string }
+  | { kind: 'node'; node: PatchNode; isNew: boolean };
+
+@customElement('artnet-patch-panel')
+export class ArtnetPatchPanel extends LitElement {
+  @property({ attribute: false }) hass!: HomeAssistant;
+  @property({ type: Boolean }) narrow = false;
+
+  @state() private _patch: PatchDoc = { nodes: [] };
+  @state() private _yamlNodes: YamlNodeSnapshot[] = [];
+  @state() private _loaded = false;
+  @state() private _dirty = false;
+  @state() private _saving = false;
+  @state() private _errors: PatchError[] = [];
+  @state() private _toast = '';
+  /** Selected node: 'ui:<idx>' or 'yaml:<idx>'. */
+  @state() private _selected = '';
+  @state() private _selectedUniverse = '';
+  @state() private _dialog: DialogState = { kind: 'none' };
+
+  private _toastTimer?: number;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._load();
+    window.addEventListener('beforeunload', this._beforeUnload);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener('beforeunload', this._beforeUnload);
+  }
+
+  private _beforeUnload = (e: BeforeUnloadEvent) => {
+    if (this._dirty) e.preventDefault();
+  };
+
+  private async _load() {
+    try {
+      const result = await getPatch(this.hass);
+      this._patch = result.patch ?? { nodes: [] };
+      this._yamlNodes = result.yaml_nodes ?? [];
+      this._loaded = true;
+      this._autoSelect();
+    } catch (err) {
+      this._showToast(`Failed to load patch: ${err}`);
+    }
+  }
+
+  private _autoSelect() {
+    if (this._selected) return;
+    if (this._patch.nodes.length) this._selectNode('ui:0');
+    else if (this._yamlNodes.length) this._selectNode('yaml:0');
+  }
+
+  private _selectNode(id: string) {
+    this._selected = id;
+    const universes = this._currentUniverses();
+    const keys = Object.keys(universes ?? {}).sort((a, b) => Number(a) - Number(b));
+    this._selectedUniverse = keys[0] ?? '';
+  }
+
+  private _currentNode(): PatchNode | YamlNodeSnapshot | undefined {
+    const [kind, idxStr] = this._selected.split(':');
+    const idx = Number(idxStr);
+    if (kind === 'ui') return this._patch.nodes[idx];
+    if (kind === 'yaml') return this._yamlNodes[idx];
+    return undefined;
+  }
+
+  private _isYamlSelected(): boolean {
+    return this._selected.startsWith('yaml:');
+  }
+
+  private _currentUniverses(): Record<string, PatchUniverse> | undefined {
+    return this._currentNode()?.universes as Record<string, PatchUniverse> | undefined;
+  }
+
+  private _markDirty() {
+    this._dirty = true;
+    this._patch = { ...this._patch, nodes: [...this._patch.nodes] };
+  }
+
+  private async _save() {
+    this._saving = true;
+    this._errors = [];
+    try {
+      const result = await savePatch(this.hass, this._patch);
+      if (result.success) {
+        this._dirty = false;
+        this._showToast('Patch saved — changes applied live');
+      } else {
+        this._errors = result.errors;
+        this._showToast('Patch has errors; nothing was saved');
+      }
+    } catch (err) {
+      this._showToast(`Save failed: ${err}`);
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  private _showToast(message: string) {
+    this._toast = message;
+    clearTimeout(this._toastTimer);
+    this._toastTimer = window.setTimeout(() => (this._toast = ''), 4000);
+  }
+
+  // ---- node CRUD ----------------------------------------------------------
+
+  private _addNode() {
+    this._dialog = { kind: 'node', node: newNode(), isNew: true };
+  }
+
+  private _editNode() {
+    const node = this._currentNode();
+    if (!node || this._isYamlSelected()) return;
+    this._dialog = { kind: 'node', node: node as PatchNode, isNew: false };
+  }
+
+  private _onSaveNode(e: CustomEvent) {
+    const { node, original } = e.detail as { node: PatchNode; original: PatchNode };
+    const nodes = this._patch.nodes;
+    const idx = nodes.findIndex((n) => n.id === original.id);
+    if (idx >= 0) nodes[idx] = node;
+    else {
+      nodes.push(node);
+      this._selectNode(`ui:${nodes.length - 1}`);
+    }
+    this._dialog = { kind: 'none' };
+    this._markDirty();
+  }
+
+  private _onDeleteNode(e: CustomEvent) {
+    const { node } = e.detail as { node: PatchNode };
+    this._patch.nodes = this._patch.nodes.filter((n) => n.id !== node.id);
+    this._dialog = { kind: 'none' };
+    this._selected = '';
+    this._autoSelect();
+    this._markDirty();
+  }
+
+  // ---- universe CRUD ------------------------------------------------------
+
+  private _addUniverse() {
+    if (this._isYamlSelected()) return;
+    const node = this._currentNode() as PatchNode | undefined;
+    if (!node) return;
+    const input = prompt('Universe number (0-1024):', '0');
+    if (input === null) return;
+    const nr = String(Number(input));
+    if (Number.isNaN(Number(input)) || Number(nr) < 0 || Number(nr) > 1024) {
+      this._showToast('Universe must be a number between 0 and 1024');
+      return;
+    }
+    if (node.universes[nr]) {
+      this._showToast(`Universe ${nr} already exists`);
+      return;
+    }
+    node.universes = {
+      ...node.universes,
+      [nr]: { send_partial_universe: true, output_correction: 'linear', devices: [] },
+    };
+    this._selectedUniverse = nr;
+    this._markDirty();
+  }
+
+  private _removeUniverse() {
+    if (this._isYamlSelected()) return;
+    const node = this._currentNode() as PatchNode | undefined;
+    if (!node || !this._selectedUniverse) return;
+    const devices = node.universes[this._selectedUniverse]?.devices ?? [];
+    if (devices.length && !confirm(`Delete universe ${this._selectedUniverse} and its ${devices.length} fixture(s)?`)) {
+      return;
+    }
+    const universes = { ...node.universes };
+    delete universes[this._selectedUniverse];
+    node.universes = universes;
+    const keys = Object.keys(universes).sort((a, b) => Number(a) - Number(b));
+    this._selectedUniverse = keys[0] ?? '';
+    this._markDirty();
+  }
+
+  private _setUniverseOption(key: 'output_correction' | 'send_partial_universe', value: unknown) {
+    if (this._isYamlSelected()) return;
+    const node = this._currentNode() as PatchNode | undefined;
+    const universe = node?.universes[this._selectedUniverse];
+    if (!universe) return;
+    (universe as unknown as Record<string, unknown>)[key] = value;
+    this._markDirty();
+  }
+
+  // ---- device CRUD --------------------------------------------------------
+
+  private _onAddDevice(e: CustomEvent) {
+    if (this._isYamlSelected()) return;
+    this._dialog = {
+      kind: 'device',
+      device: newDevice(e.detail.channel),
+      isNew: true,
+      universeNr: this._selectedUniverse,
+    };
+  }
+
+  private _onEditDevice(e: CustomEvent) {
+    if (this._isYamlSelected()) return;
+    this._dialog = {
+      kind: 'device',
+      device: e.detail.device,
+      isNew: false,
+      universeNr: this._selectedUniverse,
+    };
+  }
+
+  private _onSaveDevice(e: CustomEvent) {
+    const { device, original } = e.detail as { device: PatchDevice; original: PatchDevice };
+    if (this._dialog.kind !== 'device') return;
+    const node = this._currentNode() as PatchNode | undefined;
+    const universe = node?.universes[this._dialog.universeNr];
+    if (!universe) return;
+    const idx = universe.devices.findIndex((d) => d.id === original.id);
+    if (idx >= 0) universe.devices[idx] = device;
+    else universe.devices.push(device);
+    universe.devices = [...universe.devices];
+    this._dialog = { kind: 'none' };
+    this._markDirty();
+  }
+
+  private _onDeleteDevice(e: CustomEvent) {
+    const { device } = e.detail as { device: PatchDevice };
+    if (this._dialog.kind !== 'device') return;
+    const node = this._currentNode() as PatchNode | undefined;
+    const universe = node?.universes[this._dialog.universeNr];
+    if (!universe) return;
+    universe.devices = universe.devices.filter((d) => d.id !== device.id);
+    this._dialog = { kind: 'none' };
+    this._markDirty();
+  }
+
+  // ---- render -------------------------------------------------------------
+
+  render() {
+    if (!this._loaded) {
+      return html`<div class="loading">Loading DMX patch…</div>`;
+    }
+
+    const node = this._currentNode();
+    const isYaml = this._isYamlSelected();
+    const universes = this._currentUniverses() ?? {};
+    const universeKeys = Object.keys(universes).sort((a, b) => Number(a) - Number(b));
+    const universe = universes[this._selectedUniverse];
+
+    return html`
+      <div class="header">
+        <h1>DMX Patch</h1>
+        ${this._dirty ? html`<span class="dirty">unsaved changes</span>` : nothing}
+        <span class="spacer"></span>
+        <button
+          class="primary"
+          ?disabled=${!this._dirty || this._saving}
+          @click=${this._save}
+        >
+          ${this._saving ? 'Saving…' : 'Save & Apply'}
+        </button>
+      </div>
+
+      <div class="layout ${this.narrow ? 'narrow' : ''}">
+        <nav class="rail">
+          <div class="rail-section">Patch nodes</div>
+          ${this._patch.nodes.map(
+            (n, i) => html`
+              <button
+                class="rail-item ${this._selected === `ui:${i}` ? 'active' : ''}"
+                @click=${() => this._selectNode(`ui:${i}`)}
+              >
+                <span class="rail-title">${n.host || '(new node)'}</span>
+                <span class="rail-sub">${n.node_type}</span>
+              </button>
+            `
+          )}
+          <button class="rail-add" @click=${this._addNode}>+ Add node</button>
+
+          ${this._yamlNodes.length
+            ? html`
+                <div class="rail-section">YAML nodes 🔒</div>
+                ${this._yamlNodes.map(
+                  (n, i) => html`
+                    <button
+                      class="rail-item ${this._selected === `yaml:${i}` ? 'active' : ''}"
+                      @click=${() => this._selectNode(`yaml:${i}`)}
+                    >
+                      <span class="rail-title">${n.host}</span>
+                      <span class="rail-sub">${n.node_type} · read-only</span>
+                    </button>
+                  `
+                )}
+              `
+            : nothing}
+        </nav>
+
+        <main class="main">
+          ${!node
+            ? html`<div class="empty">
+                No nodes yet. Add a node to start patching, or configure one in YAML.
+              </div>`
+            : html`
+                <div class="node-bar">
+                  <h2>${node.host} <small>(${node.node_type})</small></h2>
+                  ${!isYaml
+                    ? html`<button @click=${this._editNode}>Node settings</button>`
+                    : nothing}
+                </div>
+
+                <div class="universe-bar">
+                  ${universeKeys.map(
+                    (key) => html`
+                      <button
+                        class="tab ${this._selectedUniverse === key ? 'active' : ''}"
+                        @click=${() => (this._selectedUniverse = key)}
+                      >
+                        Universe ${key}
+                      </button>
+                    `
+                  )}
+                  ${!isYaml
+                    ? html`
+                        <button class="tab add" @click=${this._addUniverse}>+</button>
+                        ${this._selectedUniverse
+                          ? html`<button class="tab remove" @click=${this._removeUniverse}>
+                              Remove universe
+                            </button>`
+                          : nothing}
+                      `
+                    : nothing}
+                </div>
+
+                ${universe
+                  ? html`
+                      <div class="universe-options">
+                        <label>
+                          Output correction
+                          <select
+                            ?disabled=${isYaml}
+                            @change=${(e: Event) =>
+                              this._setUniverseOption(
+                                'output_correction',
+                                (e.target as HTMLSelectElement).value
+                              )}
+                          >
+                            ${CORRECTIONS.map(
+                              (c) =>
+                                html`<option
+                                  value=${c}
+                                  ?selected=${(universe.output_correction ?? 'linear') === c}
+                                >
+                                  ${c}
+                                </option>`
+                            )}
+                          </select>
+                        </label>
+                        <label>
+                          <input
+                            type="checkbox"
+                            ?disabled=${isYaml}
+                            .checked=${universe.send_partial_universe ?? true}
+                            @change=${(e: Event) =>
+                              this._setUniverseOption(
+                                'send_partial_universe',
+                                (e.target as HTMLInputElement).checked
+                              )}
+                          />
+                          Send partial universe
+                        </label>
+                      </div>
+
+                      <artnet-universe-grid
+                        .hass=${this.hass}
+                        .universe=${universe}
+                        .universeNr=${Number(this._selectedUniverse)}
+                        .nodeKey=${nodeKey(node as PatchNode)}
+                        ?readonly=${isYaml}
+                        @add-device=${this._onAddDevice}
+                        @edit-device=${this._onEditDevice}
+                        @grid-error=${(e: CustomEvent) => this._showToast(e.detail)}
+                      ></artnet-universe-grid>
+                    `
+                  : html`<div class="empty">No universes. Add one to start placing fixtures.</div>`}
+              `}
+
+          ${this._errors.length
+            ? html`
+                <div class="errors">
+                  <strong>Validation errors</strong>
+                  <ul>
+                    ${this._errors.map(
+                      (err) => html`<li><code>${err.path}</code>: ${err.message}</li>`
+                    )}
+                  </ul>
+                </div>
+              `
+            : nothing}
+        </main>
+      </div>
+
+      ${this._dialog.kind === 'device'
+        ? html`
+            <artnet-device-dialog
+              .device=${this._dialog.device}
+              ?isNew=${this._dialog.isNew}
+              @dialog-closed=${() => (this._dialog = { kind: 'none' })}
+              @save-device=${this._onSaveDevice}
+              @delete-device=${this._onDeleteDevice}
+            ></artnet-device-dialog>
+          `
+        : nothing}
+      ${this._dialog.kind === 'node'
+        ? html`
+            <artnet-node-dialog
+              .node=${this._dialog.node}
+              ?isNew=${this._dialog.isNew}
+              @dialog-closed=${() => (this._dialog = { kind: 'none' })}
+              @save-node=${this._onSaveNode}
+              @delete-node=${this._onDeleteNode}
+            ></artnet-node-dialog>
+          `
+        : nothing}
+      ${this._toast ? html`<div class="toast">${this._toast}</div>` : nothing}
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      height: 100%;
+      background: var(--primary-background-color);
+      color: var(--primary-text-color);
+      font-family: var(--paper-font-body1_-_font-family, Roboto, sans-serif);
+    }
+    .loading,
+    .empty {
+      padding: 32px;
+      color: var(--secondary-text-color);
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 16px;
+      background: var(--app-header-background-color, var(--primary-color));
+      color: var(--app-header-text-color, #fff);
+    }
+    .header h1 {
+      font-size: 1.25rem;
+      font-weight: 400;
+      margin: 0;
+    }
+    .dirty {
+      font-size: 0.8rem;
+      opacity: 0.85;
+      font-style: italic;
+    }
+    .spacer {
+      flex: 1;
+    }
+    button {
+      font: inherit;
+      padding: 8px 14px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      background: var(--secondary-background-color, #f0f0f0);
+      color: var(--primary-text-color, #212121);
+    }
+    button.primary {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+    }
+    button.primary:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    .layout {
+      display: flex;
+      height: calc(100% - 56px);
+    }
+    .layout.narrow {
+      flex-direction: column;
+    }
+    .rail {
+      width: 220px;
+      flex-shrink: 0;
+      border-right: 1px solid var(--divider-color, #e0e0e0);
+      padding: 12px 8px;
+      box-sizing: border-box;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .narrow .rail {
+      width: 100%;
+      border-right: none;
+      border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+    .rail-section {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--secondary-text-color);
+      margin: 8px 8px 4px;
+    }
+    .rail-item {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      text-align: left;
+      background: none;
+      border-radius: 8px;
+      padding: 8px 10px;
+    }
+    .rail-item.active {
+      background: var(--secondary-background-color, #f0f0f0);
+    }
+    .rail-title {
+      font-weight: 500;
+    }
+    .rail-sub {
+      font-size: 0.75rem;
+      color: var(--secondary-text-color);
+    }
+    .rail-add {
+      background: none;
+      color: var(--primary-color);
+      text-align: left;
+      padding: 8px 10px;
+    }
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+      box-sizing: border-box;
+    }
+    .node-bar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+    .node-bar h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+    .node-bar small {
+      color: var(--secondary-text-color);
+      font-weight: 400;
+    }
+    .universe-bar {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin-bottom: 10px;
+    }
+    .tab {
+      border-radius: 16px;
+      padding: 6px 14px;
+    }
+    .tab.active {
+      background: var(--primary-color);
+      color: var(--text-primary-color, #fff);
+    }
+    .tab.add {
+      font-weight: 700;
+    }
+    .tab.remove {
+      color: var(--error-color, #db4437);
+      background: none;
+    }
+    .universe-options {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      margin-bottom: 12px;
+      font-size: 0.9rem;
+    }
+    .universe-options label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .universe-options select {
+      font: inherit;
+      padding: 4px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--divider-color, #e0e0e0);
+      background: var(--secondary-background-color, #fafafa);
+      color: var(--primary-text-color);
+    }
+    .errors {
+      margin-top: 16px;
+      padding: 12px 16px;
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--error-color, #db4437) 12%, transparent);
+      border: 1px solid var(--error-color, #db4437);
+      font-size: 0.9rem;
+    }
+    .errors ul {
+      margin: 8px 0 0;
+      padding-left: 20px;
+    }
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--primary-text-color);
+      color: var(--primary-background-color);
+      padding: 10px 20px;
+      border-radius: 24px;
+      font-size: 0.9rem;
+      z-index: 20;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    }
+  `;
+}

--- a/custom_components/artnet_led/frontend/src/universe-grid.ts
+++ b/custom_components/artnet_led/frontend/src/universe-grid.ts
@@ -1,0 +1,231 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  PatchDevice,
+  PatchUniverse,
+  HomeAssistant,
+  footprint,
+  deviceColor,
+} from './model';
+import { subscribeDmx, DmxFrame } from './ws';
+
+/** 512-channel grid for one universe. Fires 'add-device' / 'edit-device' events. */
+@customElement('artnet-universe-grid')
+export class ArtnetUniverseGrid extends LitElement {
+  @property({ attribute: false }) hass!: HomeAssistant;
+  @property({ attribute: false }) universe!: PatchUniverse;
+  @property() nodeKey = '';
+  @property({ type: Number }) universeNr = 0;
+  @property({ type: Boolean }) readonly = false;
+
+  @state() private _live = false;
+  @state() private _values: number[] = [];
+
+  private _unsub?: () => Promise<void>;
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._stopLive();
+  }
+
+  private async _toggleLive() {
+    if (this._live) {
+      this._stopLive();
+      this._live = false;
+      return;
+    }
+    this._live = true;
+    try {
+      this._unsub = await subscribeDmx(
+        this.hass,
+        this.nodeKey,
+        this.universeNr,
+        (frame: DmxFrame) => {
+          this._values = frame.values;
+        }
+      );
+    } catch (err) {
+      this._live = false;
+      this.dispatchEvent(
+        new CustomEvent('grid-error', {
+          detail: `Live monitoring unavailable: ${err}`,
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  }
+
+  private _stopLive() {
+    this._unsub?.();
+    this._unsub = undefined;
+    this._values = [];
+  }
+
+  /** channel (1-based) → device + its index, for occupied cells. */
+  private _channelMap(): Map<number, { device: PatchDevice; index: number; first: boolean }> {
+    const map = new Map();
+    (this.universe?.devices ?? []).forEach((device, index) => {
+      const [first, last] = footprint(device);
+      for (let ch = first; ch <= Math.min(last, 512); ch++) {
+        const existing = map.get(ch);
+        map.set(ch, { device, index, first: ch === first, overlap: !!existing });
+      }
+    });
+    return map;
+  }
+
+  render() {
+    const map = this._channelMap();
+    const cells = [];
+    for (let ch = 1; ch <= 512; ch++) {
+      const entry = map.get(ch) as
+        | { device: PatchDevice; index: number; first: boolean; overlap?: boolean }
+        | undefined;
+      const value = this._values[ch - 1];
+      const heat = this._live && value !== undefined ? value / 255 : 0;
+      cells.push(html`
+        <div
+          class="cell ${entry ? 'occupied' : ''} ${entry?.overlap ? 'overlap' : ''}"
+          style=${entry
+            ? `--device-color: ${deviceColor(entry.index)}`
+            : nothing}
+          title=${entry
+            ? `${entry.device.name} (${entry.device.type}) — channel ${ch}`
+            : `Channel ${ch}`}
+          @click=${() => this._cellClick(ch, entry?.device)}
+        >
+          ${this._live
+            ? html`<span class="heat" style="opacity: ${heat}"></span>`
+            : nothing}
+          <span class="ch">${ch}</span>
+          ${entry?.first
+            ? html`<span class="name">${entry.device.name}</span>`
+            : nothing}
+          ${this._live && value !== undefined
+            ? html`<span class="val">${value}</span>`
+            : nothing}
+        </div>
+      `);
+    }
+
+    return html`
+      <div class="toolbar">
+        <label class="live-toggle">
+          <input
+            type="checkbox"
+            .checked=${this._live}
+            @change=${this._toggleLive}
+          />
+          Live DMX values
+        </label>
+        ${this.readonly
+          ? html`<span class="readonly-hint">YAML-configured (read-only)</span>`
+          : nothing}
+      </div>
+      <div class="grid">${cells}</div>
+    `;
+  }
+
+  private _cellClick(channel: number, device?: PatchDevice) {
+    if (this.readonly) return;
+    if (device) {
+      this.dispatchEvent(
+        new CustomEvent('edit-device', { detail: { device }, bubbles: true, composed: true })
+      );
+    } else {
+      this.dispatchEvent(
+        new CustomEvent('add-device', { detail: { channel }, bubbles: true, composed: true })
+      );
+    }
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 8px;
+    }
+    .live-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.9rem;
+      color: var(--primary-text-color);
+      cursor: pointer;
+    }
+    .readonly-hint {
+      font-size: 0.85rem;
+      color: var(--secondary-text-color);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+      gap: 2px;
+    }
+    .cell {
+      position: relative;
+      aspect-ratio: 1;
+      min-width: 0;
+      border-radius: 4px;
+      background: var(--secondary-background-color, #f0f0f0);
+      cursor: pointer;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 3px 4px;
+      box-sizing: border-box;
+      border: 1px solid transparent;
+    }
+    .cell:hover {
+      border-color: var(--primary-color);
+    }
+    .cell.occupied {
+      background: var(--device-color);
+      color: #fff;
+    }
+    .cell.overlap {
+      outline: 2px solid var(--error-color, #db4437);
+      outline-offset: -2px;
+    }
+    .heat {
+      position: absolute;
+      inset: 0;
+      background: var(--primary-color, #03a9f4);
+      pointer-events: none;
+    }
+    .cell.occupied .heat {
+      background: #fff;
+      mix-blend-mode: overlay;
+    }
+    .ch {
+      position: relative;
+      font-size: 0.6rem;
+      opacity: 0.7;
+      line-height: 1;
+    }
+    .name {
+      position: relative;
+      font-size: 0.62rem;
+      font-weight: 600;
+      line-height: 1.1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      word-break: break-all;
+    }
+    .val {
+      position: relative;
+      font-size: 0.65rem;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+  `;
+}

--- a/custom_components/artnet_led/frontend/src/ws.ts
+++ b/custom_components/artnet_led/frontend/src/ws.ts
@@ -1,0 +1,54 @@
+import type { HomeAssistant, PatchDoc, PatchError, YamlNodeSnapshot } from './model';
+
+export interface PatchGetResult {
+  schema_version: number;
+  patch: PatchDoc;
+  yaml_nodes: YamlNodeSnapshot[];
+  entry_exists: boolean;
+}
+
+export interface SaveResult {
+  success: boolean;
+  errors: PatchError[];
+}
+
+export interface DmxFrame {
+  node_key: string;
+  universe: number;
+  seq: number;
+  values: number[];
+}
+
+export const getPatch = (hass: HomeAssistant) =>
+  hass.callWS<PatchGetResult>({ type: 'artnet_led/patch/get' });
+
+export const validatePatch = (hass: HomeAssistant, patch: PatchDoc) =>
+  hass.callWS<{ valid: boolean; errors: PatchError[] }>({
+    type: 'artnet_led/patch/validate',
+    patch,
+  });
+
+export const savePatch = (hass: HomeAssistant, patch: PatchDoc) =>
+  hass.callWS<SaveResult>({ type: 'artnet_led/patch/save', patch });
+
+export const getStatus = (hass: HomeAssistant) =>
+  hass.callWS<{ nodes: unknown[]; discovered: unknown[] }>({
+    type: 'artnet_led/status/get',
+  });
+
+export const getEntityMap = (hass: HomeAssistant) =>
+  hass.callWS<{ entities: Record<string, string> }>({
+    type: 'artnet_led/entity_map/get',
+  });
+
+export const subscribeDmx = (
+  hass: HomeAssistant,
+  nodeKey: string,
+  universe: number,
+  callback: (frame: DmxFrame) => void
+) =>
+  hass.connection.subscribeMessage<DmxFrame>(callback, {
+    type: 'artnet_led/dmx/subscribe',
+    node_key: nodeKey,
+    universe,
+  });

--- a/custom_components/artnet_led/frontend/tsconfig.json
+++ b/custom_components/artnet_led/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2021", "dom", "dom.iterable"],
+    "strict": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/custom_components/artnet_led/light.py
+++ b/custom_components/artnet_led/light.py
@@ -28,212 +28,79 @@ from homeassistant.const import CONF_NAME as CONF_DEVICE_NAME
 from homeassistant.const import CONF_PORT as CONF_NODE_PORT
 from homeassistant.const import CONF_TYPE as CONF_DEVICE_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util.color import color_rgb_to_rgbw
-from pyartnet import BaseUniverse, Channel
-from pyartnet.errors import UniverseNotFoundError
+from pyartnet import Channel
 
 from custom_components.artnet_led.bridge.artnet_controller import ArtNetController
 from custom_components.artnet_led.bridge.channel_bridge import ChannelBridge
+from custom_components.artnet_led.const import (
+    AVAILABLE_CORRECTIONS,
+    CHANNEL_SIZE,
+    CONF_BYTE_ORDER,
+    CONF_CHANNEL_SETUP,
+    CONF_CHANNEL_SIZE,
+    CONF_DEVICE_CHANNEL,
+    CONF_DEVICE_MAX_TEMP,
+    CONF_DEVICE_MIN_TEMP,
+    CONF_NODE_HOST_OVERRIDE,
+    CONF_NODE_MAX_FPS,
+    CONF_NODE_PORT_OVERRIDE,
+    CONF_NODE_REFRESH,
+    CONF_NODE_TYPE,
+    CONF_NODE_UNIVERSES,
+    CONF_OUTPUT_CORRECTION,
+    CONF_SEND_PARTIAL_UNIVERSE,
+    NODE_TYPES,
+    OWNER_YAML,
+    UNIQUE_ID_PREFIX,
+)
+from custom_components.artnet_led.entity_factory import create_light_entities
+from custom_components.artnet_led.runtime import ArtNetRuntime, NodeConflictError
 from custom_components.artnet_led.util.channel_switch import validate, to_values, from_values
-
-ARTNET_DEFAULT_PORT = 6454
-SACN_DEFAULT_PORT = 5568
-KINET_DEFAULT_PORT = 6038
 
 CONF_DEVICE_TRANSITION = ATTR_TRANSITION
 
-CONF_SEND_PARTIAL_UNIVERSE = "send_partial_universe"
-
 log = logging.getLogger(__name__)
 
-CONF_NODE_HOST_OVERRIDE = "host_override"
-CONF_NODE_PORT_OVERRIDE = "port_override"
-
-CONF_NODE_TYPE = "node_type"
-CONF_NODE_MAX_FPS = "max_fps"
-CONF_NODE_REFRESH = "refresh_every"
-CONF_NODE_UNIVERSES = "universes"
-
-CONF_DEVICE_CHANNEL = "channel"
-CONF_OUTPUT_CORRECTION = "output_correction"
-CONF_CHANNEL_SIZE = "channel_size"
-CONF_BYTE_ORDER = "byte_order"
-
-CONF_DEVICE_MIN_TEMP = "min_temp"
-CONF_DEVICE_MAX_TEMP = "max_temp"
-CONF_CHANNEL_SETUP = "channel_setup"
-
-DOMAIN = "dmx"
-
-AVAILABLE_CORRECTIONS = {"linear": pyartnet.output_correction.linear, "quadratic": pyartnet.output_correction.quadratic,
-                         "cubic": pyartnet.output_correction.cubic, "quadruple": pyartnet.output_correction.quadruple}
-
-type LogicalChannelSize = int
-type LogicalChannelNumBytes = int
-type ChannelSize = tuple[LogicalChannelSize, LogicalChannelNumBytes]
-
-CHANNEL_SIZE: dict[str, ChannelSize] = {
-    "8bit": (1, 1),
-    "16bit": (2, 256),
-    "24bit": (3, 256 ** 2),
-    "32bit": (4, 256 ** 3),
-}
-
-NODES = {}
+# Historical alias: this module's "domain" is the unique_id prefix, not the integration domain.
+DOMAIN = UNIQUE_ID_PREFIX
 
 
 async def async_setup_platform(hass: HomeAssistant, config, async_add_devices, discovery_info=None):
-    # pyartnet expects the created asyncio task to be the task running its wrapper.
-    # Home Assistant's task factory can wrap tasks, which breaks pyartnet's assertions.
-    pyartnet.base.background_task.CREATE_TASK = asyncio.create_task
-
-    client_type = config.get(CONF_NODE_TYPE)
-    max_fps = config.get(CONF_NODE_MAX_FPS)
-    refresh_interval = config.get(CONF_NODE_REFRESH)
+    runtime = ArtNetRuntime.get(hass)
 
     host = config.get(CONF_NODE_HOST)
-    port = config.get(CONF_NODE_PORT)
 
-    real_host = config.get(CONF_NODE_HOST_OVERRIDE)
-    if len(real_host) == 0:
-        real_host = host
-    real_port = config.get(CONF_NODE_PORT_OVERRIDE)
-    if real_port == None:
-        real_port = port
+    try:
+        handle = await runtime.acquire_node(config, owner=OWNER_YAML)
+    except NodeConflictError as e:
+        log.error("Cannot set up YAML node: %s", e)
+        return False
 
-    # setup Node
-    node: pyartnet.base.BaseNode
-    if client_type == "artnet-direct":
-        if real_port is None:
-            real_port = ARTNET_DEFAULT_PORT
-
-        __id = f"{host}:{port}"
-        if __id not in NODES:
-            from pyartnet.base.network import UnicastNetworkTarget
-            __node = pyartnet.ArtNetNode(
-                UnicastNetworkTarget.create(real_host, real_port),
-                max_fps=max_fps,
-                refresh_every=refresh_interval,
-            )
-            await __node.__aenter__()
-            if not refresh_interval:
-                await __node.stop_refresh()
-            NODES[__id] = __node
-
-        node = NODES[__id]
-
-    elif client_type == "artnet-controller":
-        if "server" not in NODES:
-            __node = ArtNetController(hass, max_fps=max_fps, refresh_every=refresh_interval)
-            NODES["server"] = __node
-            __node.start()
-        node = NODES["server"]
-
-    elif client_type == "sacn":
-        if real_port is None:
-            real_port = SACN_DEFAULT_PORT
-
-        __id = f"{host}:{port}"
-        if __id not in NODES:
-            from pyartnet.base.network import UnicastNetworkTarget
-            __node = pyartnet.SacnNode(
-                UnicastNetworkTarget.create(real_host, real_port),
-                max_fps=max_fps,
-                refresh_every=refresh_interval,
-                source_name="ha-artnet-led"
-            )
-            await __node.__aenter__()
-            if not refresh_interval:
-                await __node.stop_refresh()
-            NODES[__id] = __node
-
-        node = NODES[__id]
-    elif client_type == "kinet":
-        if real_port is None:
-            real_port = KINET_DEFAULT_PORT
-
-        __id = f"{host}:{port}"
-        if __id not in NODES:
-            from pyartnet.base.network import UnicastNetworkTarget
-            __node = pyartnet.KiNetNode(
-                UnicastNetworkTarget.create(real_host, real_port),
-                max_fps=max_fps,
-                refresh_every=refresh_interval,
-            )
-            await __node.__aenter__()
-            if not refresh_interval:
-                await __node.stop_refresh()
-            NODES[__id] = __node
-
-        node = NODES[__id]
-
-    else:
-        raise NotImplementedError(f"Unknown client type '{client_type}'")
-
-    entity_registry = async_get(hass)
-
-    device_list = []
-    used_unique_ids = []
-    for universe_nr, universe_cfg in config[CONF_NODE_UNIVERSES].items():
-        try:
-            universe = node.get_universe(universe_nr)
-        except UniverseNotFoundError:
-            universe: BaseUniverse = node.add_universe(universe_nr)
-            universe.set_output_correction(AVAILABLE_CORRECTIONS.get(
-                universe_cfg[CONF_OUTPUT_CORRECTION]
-            ))
-
-        for device in universe_cfg[CONF_DEVICES]:  # type: dict
-            device = device.copy()
-            cls = __CLASS_TYPE[device[CONF_DEVICE_TYPE]]
-
-            channel = device[CONF_DEVICE_CHANNEL]
-            unique_id = f"{DOMAIN}:{host}/{universe_nr}/{channel}"
-
-            name: str = device[CONF_DEVICE_NAME]
-            byte_size = CHANNEL_SIZE[device[CONF_CHANNEL_SIZE]][0]
-            byte_order = device[CONF_BYTE_ORDER]
-
-            entity_id = f"light.{slugify(name)}"
-
-            # If the entity has another unique ID, use that until it's migrated properly
-            entity = entity_registry.async_get(entity_id)
-            if entity:
-                log.info(f"Found existing entity for name {entity_id}, using unique id {unique_id}")
-                if entity.unique_id is not None and entity.unique_id not in used_unique_ids:
-                    unique_id = entity.unique_id
-            used_unique_ids.append(unique_id)
-
-            # create device
-            device["unique_id"] = unique_id
-            d = cls(**device)  # type: DmxBaseLight
-            d.set_type(device[CONF_DEVICE_TYPE])
-
-            d.set_channel(
-                universe.add_channel(
-                    start=channel,
-                    width=d.channel_width,
-                    channel_name=d.name,
-                    byte_size=byte_size,
-                    byte_order=byte_order,
-                )
-            )
-
-            d.channel.set_output_correction(AVAILABLE_CORRECTIONS.get(
-                device[CONF_OUTPUT_CORRECTION]
-            ))
-
-            device_list.append(d)
-
-            send_partial_universe = universe_cfg[CONF_SEND_PARTIAL_UNIVERSE]
-            if not send_partial_universe:
-                universe._resize_universe(512)
+    device_list = create_light_entities(hass, handle.node, host, config[CONF_NODE_UNIVERSES])
+    handle.record_universes(config[CONF_NODE_UNIVERSES])
 
     async_add_devices(device_list)
 
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    """Set up lights for the UI-defined patch (config entry)."""
+    from custom_components.artnet_led.const import DATA_ENTRY_NODES, DOMAIN as INTEGRATION_DOMAIN
+
+    entry_nodes = hass.data[INTEGRATION_DOMAIN][DATA_ENTRY_NODES].get(entry.entry_id, [])
+
+    entities = []
+    used_unique_ids = []
+    for handle, universes_cfg in entry_nodes:
+        entities.extend(
+            create_light_entities(hass, handle.node, handle.host, universes_cfg, used_unique_ids)
+        )
+        handle.record_universes(universes_cfg)
+
+    async_add_entities(entities)
 
 
 def convert_to_kelvin(kelvin_string) -> int:
@@ -1033,52 +900,59 @@ class DmxXY(DmxBaseLight):
 __CLASS_LIST = [DmxDimmer, DmxRGB, DmxWhite, DmxRGBW, DmxRGBWW, DmxBinary, DmxFixed, DmxXY]
 __CLASS_TYPE = {k.CONF_TYPE: k for k in __CLASS_LIST}
 
+# Public aliases, used by the entity factory and the UI patch validation.
+CLASS_LIST = __CLASS_LIST
+CLASS_TYPE = __CLASS_TYPE
+
+DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_CHANNEL): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=512)
+        ),
+        vol.Required(CONF_DEVICE_NAME): cv.string,
+        vol.Optional(CONF_DEVICE_FRIENDLY_NAME): cv.string,
+        vol.Optional(CONF_DEVICE_TYPE, default='dimmer'): vol.In(
+            [k.CONF_TYPE for k in __CLASS_LIST]
+        ),
+        vol.Optional(CONF_DEVICE_TRANSITION, default=0): vol.All(
+            vol.Coerce(float), vol.Range(min=0, max=999)
+        ),
+        vol.Optional(CONF_OUTPUT_CORRECTION, default=None): vol.Any(
+            None, vol.In(AVAILABLE_CORRECTIONS)
+        ),
+        vol.Optional(CONF_CHANNEL_SIZE, default='8bit'): vol.Any(
+            None, vol.In(CHANNEL_SIZE)
+        ),
+        vol.Optional(CONF_BYTE_ORDER, default='big'): vol.Any(
+            None, vol.In(['little', 'big'])
+        ),
+        vol.Optional(CONF_DEVICE_MIN_TEMP, default='2700K'): vol.Match(
+            "\\d+(k|K)"
+        ),
+        vol.Optional(CONF_DEVICE_MAX_TEMP, default='6500K'): vol.Match(
+            "\\d+(k|K)"
+        ),
+        vol.Optional(CONF_CHANNEL_SETUP, default=None): vol.Any(
+            None, cv.string, cv.ensure_list
+        ),
+    }
+)
+
+UNIVERSE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_SEND_PARTIAL_UNIVERSE, default=True): cv.boolean,
+        vol.Optional(CONF_OUTPUT_CORRECTION, default='linear'): vol.Any(
+            None, vol.In(AVAILABLE_CORRECTIONS)
+        ),
+        vol.Required(CONF_DEVICES): vol.All(cv.ensure_list, [DEVICE_SCHEMA]),
+    }
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_NODE_HOST): cv.string,
         vol.Required(CONF_NODE_UNIVERSES): {
-            vol.All(int, vol.Range(min=0, max=1024)): {
-                vol.Optional(CONF_SEND_PARTIAL_UNIVERSE, default=True): cv.boolean,
-                vol.Optional(CONF_OUTPUT_CORRECTION, default='linear'): vol.Any(
-                    None, vol.In(AVAILABLE_CORRECTIONS)
-                ),
-                CONF_DEVICES: vol.All(
-                    cv.ensure_list,
-                    [
-                        {
-                            vol.Required(CONF_DEVICE_CHANNEL): vol.All(
-                                vol.Coerce(int), vol.Range(min=1, max=512)
-                            ),
-                            vol.Required(CONF_DEVICE_NAME): cv.string,
-                            vol.Optional(CONF_DEVICE_FRIENDLY_NAME): cv.string,
-                            vol.Optional(CONF_DEVICE_TYPE, default='dimmer'): vol.In(
-                                [k.CONF_TYPE for k in __CLASS_LIST]
-                            ),
-                            vol.Optional(CONF_DEVICE_TRANSITION, default=0): vol.All(
-                                vol.Coerce(float), vol.Range(min=0, max=999)
-                            ),
-                            vol.Optional(CONF_OUTPUT_CORRECTION, default=None): vol.Any(
-                                None, vol.In(AVAILABLE_CORRECTIONS)
-                            ),
-                            vol.Optional(CONF_CHANNEL_SIZE, default='8bit'): vol.Any(
-                                None, vol.In(CHANNEL_SIZE)
-                            ),
-                            vol.Optional(CONF_BYTE_ORDER, default='big'): vol.Any(
-                                None, vol.In(['little', 'big'])
-                            ),
-                            vol.Optional(CONF_DEVICE_MIN_TEMP, default='2700K'): vol.Match(
-                                "\\d+(k|K)"
-                            ),
-                            vol.Optional(CONF_DEVICE_MAX_TEMP, default='6500K'): vol.Match(
-                                "\\d+(k|K)"
-                            ),
-                            vol.Optional(CONF_CHANNEL_SETUP, default=None): vol.Any(
-                                None, cv.string, cv.ensure_list
-                            ),
-                        }
-                    ],
-                )
-            },
+            vol.All(int, vol.Range(min=0, max=1024)): UNIVERSE_SCHEMA,
         },
         vol.Optional(CONF_NODE_HOST_OVERRIDE, default=""): cv.string,
         vol.Optional(CONF_NODE_PORT): cv.port,
@@ -1090,7 +964,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             vol.Coerce(float), vol.Range(min=0, max=9999)
         ),
         vol.Optional(CONF_NODE_TYPE, default="artnet-direct"): vol.Any(
-            None, vol.In(["artnet-direct", "artnet-controller", "sacn", "kinet"])
+            None, vol.In(NODE_TYPES)
         ),
     },
     required=True,

--- a/custom_components/artnet_led/manifest.json
+++ b/custom_components/artnet_led/manifest.json
@@ -8,11 +8,18 @@
     "@jnimmo",
     "@Breina"
   ],
+  "config_flow": true,
+  "dependencies": [
+    "http",
+    "frontend",
+    "websocket_api",
+    "panel_custom"
+  ],
   "documentation": "https://github.com/Breina/ha-artnet-led",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Breina/ha-artnet-led/issues",
   "requirements": [
     "pyartnet==2.0"
   ],
-  "version": "0.1.23"
+  "version": "0.2.0"
 }

--- a/custom_components/artnet_led/monitor.py
+++ b/custom_components/artnet_led/monitor.py
@@ -1,0 +1,90 @@
+"""Live DMX monitoring: pushes universe buffer snapshots to panel subscribers.
+
+Polls each watched universe's outbound buffer at 10 Hz and pushes only when it
+changed. Costs nothing while nobody is subscribed. Inbound DMX (controller mode)
+lands in the same buffer via the channel bridges, so it is picked up too.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable
+
+from homeassistant.core import HomeAssistant
+
+log = logging.getLogger(__name__)
+
+POLL_INTERVAL = 0.1  # 10 Hz
+
+
+class DmxMonitor:
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        self._subscribers: dict[tuple[str, int], set[Callable[[dict], None]]] = {}
+        self._tasks: dict[tuple[str, int], asyncio.Task] = {}
+        self._last_data: dict[tuple[str, int], bytes] = {}
+        self._seq: dict[tuple[str, int], int] = {}
+
+    def subscribe(
+        self, node_key: str, universe_nr: int, callback_: Callable[[dict], None]
+    ) -> Callable[[], None]:
+        key = (node_key, universe_nr)
+        self._subscribers.setdefault(key, set()).add(callback_)
+
+        if key not in self._tasks:
+            self._tasks[key] = self._hass.async_create_background_task(
+                self._poll_loop(key), f"DMX monitor {node_key}/{universe_nr}"
+            )
+
+        def unsubscribe() -> None:
+            subscribers = self._subscribers.get(key)
+            if subscribers is not None:
+                subscribers.discard(callback_)
+                if not subscribers:
+                    self._subscribers.pop(key, None)
+                    task = self._tasks.pop(key, None)
+                    if task:
+                        task.cancel()
+                    self._last_data.pop(key, None)
+                    self._seq.pop(key, None)
+
+        return unsubscribe
+
+    async def _poll_loop(self, key: tuple[str, int]) -> None:
+        while True:
+            try:
+                self._tick(key)
+            except Exception:
+                log.exception("DMX monitor tick failed for %s", key)
+            await asyncio.sleep(POLL_INTERVAL)
+
+    def _tick(self, key: tuple[str, int]) -> None:
+        from custom_components.artnet_led.runtime import ArtNetRuntime
+
+        node_key, universe_nr = key
+
+        handle = ArtNetRuntime.get(self._hass).get_handle(node_key)
+        if handle is None:
+            return
+
+        try:
+            universe = handle.node.get_universe(universe_nr)
+        except Exception:
+            return
+
+        data = bytes(universe._data)
+        if data == self._last_data.get(key):
+            return
+        self._last_data[key] = data
+
+        seq = self._seq.get(key, 0) + 1
+        self._seq[key] = seq
+
+        payload = {
+            "node_key": node_key,
+            "universe": universe_nr,
+            "seq": seq,
+            "values": list(data),
+        }
+        for subscriber in list(self._subscribers.get(key, ())):
+            subscriber(payload)

--- a/custom_components/artnet_led/runtime.py
+++ b/custom_components/artnet_led/runtime.py
@@ -1,0 +1,212 @@
+"""Owns the lifecycle of pyartnet nodes so they can be created, shared and torn down cleanly."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import pyartnet
+import pyartnet.base.background_task
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
+
+from custom_components.artnet_led.bridge.artnet_controller import ArtNetController
+from custom_components.artnet_led.const import (
+    ARTNET_DEFAULT_PORT,
+    CONF_NODE_HOST_OVERRIDE,
+    CONF_NODE_MAX_FPS,
+    CONF_NODE_PORT_OVERRIDE,
+    CONF_NODE_REFRESH,
+    CONF_NODE_TYPE,
+    DATA_RUNTIME,
+    DOMAIN,
+    KINET_DEFAULT_PORT,
+    NODE_TYPE_ARTNET_CONTROLLER,
+    NODE_TYPE_ARTNET_DIRECT,
+    NODE_TYPE_KINET,
+    NODE_TYPE_SACN,
+    SACN_DEFAULT_PORT,
+)
+from homeassistant.const import CONF_HOST as CONF_NODE_HOST
+from homeassistant.const import CONF_PORT as CONF_NODE_PORT
+
+log = logging.getLogger(__name__)
+
+
+class NodeConflictError(Exception):
+    """Raised when a node is already owned by a different config source."""
+
+
+def node_key(node_type: str, host: str | None, port: int | None) -> str:
+    """Unique runtime key for a node. The controller binds UDP 6454 so it is a singleton.
+
+    Must stay in sync with nodeKey() in the panel frontend (frontend/src/model.ts).
+    """
+    if node_type == NODE_TYPE_ARTNET_CONTROLLER:
+        return NODE_TYPE_ARTNET_CONTROLLER
+    return f"{node_type}:{host}:{port if port is not None else 'default'}"
+
+
+@dataclass
+class NodeHandle:
+    """A running pyartnet node plus the bookkeeping needed to display and tear it down."""
+
+    key: str
+    node: Any  # pyartnet.base.BaseNode or ArtNetController
+    owner: str  # OWNER_YAML or a config entry_id
+    node_type: str
+    host: str
+    port: int | None
+    # Universe configs as fed to the entity factory, kept for the panel's read-only view.
+    universes_cfg: dict[int, dict] = field(default_factory=dict)
+
+    def record_universes(self, universes_cfg: dict[int, dict]) -> None:
+        for nr, cfg in universes_cfg.items():
+            self.universes_cfg[int(nr)] = cfg
+
+
+class ArtNetRuntime:
+    """Registry of running nodes, stored in hass.data. Replaces the old module-level NODES dict."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        self._handles: dict[str, NodeHandle] = {}
+
+    @staticmethod
+    def get(hass: HomeAssistant) -> "ArtNetRuntime":
+        data = hass.data.setdefault(DOMAIN, {})
+        runtime = data.get(DATA_RUNTIME)
+        if runtime is None:
+            runtime = ArtNetRuntime(hass)
+            data[DATA_RUNTIME] = runtime
+
+            async def _on_hass_stop(_event) -> None:
+                await runtime.release_all()
+
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_hass_stop)
+        return runtime
+
+    def handles(self, owner: str | None = None) -> list[NodeHandle]:
+        if owner is None:
+            return list(self._handles.values())
+        return [h for h in self._handles.values() if h.owner == owner]
+
+    def get_handle(self, key: str) -> NodeHandle | None:
+        return self._handles.get(key)
+
+    async def acquire_node(self, node_cfg: dict, owner: str) -> NodeHandle:
+        """Return a running node for this config, creating it if needed.
+
+        The same owner may acquire the same node multiple times (e.g. multiple YAML
+        platform entries pointing at one gateway); different owners may not.
+        """
+        # pyartnet expects the created asyncio task to be the task running its wrapper.
+        # Home Assistant's task factory can wrap tasks, which breaks pyartnet's assertions.
+        pyartnet.base.background_task.CREATE_TASK = asyncio.create_task
+
+        node_type = node_cfg.get(CONF_NODE_TYPE)
+        max_fps = node_cfg.get(CONF_NODE_MAX_FPS)
+        refresh_interval = node_cfg.get(CONF_NODE_REFRESH)
+
+        host = node_cfg.get(CONF_NODE_HOST)
+        port = node_cfg.get(CONF_NODE_PORT)
+
+        real_host = node_cfg.get(CONF_NODE_HOST_OVERRIDE) or host
+        real_port = node_cfg.get(CONF_NODE_PORT_OVERRIDE)
+        if real_port is None:
+            real_port = port
+
+        key = node_key(node_type, host, port)
+
+        existing = self._handles.get(key)
+        if existing is not None:
+            if existing.owner != owner:
+                raise NodeConflictError(
+                    f"Node '{key}' is already configured by "
+                    f"{'YAML' if existing.owner == 'yaml' else 'the UI patch'};"
+                    f" it cannot be configured twice."
+                )
+            return existing
+
+        if node_type == NODE_TYPE_ARTNET_DIRECT:
+            node = await self._create_stock_node(
+                pyartnet.ArtNetNode, real_host, real_port or ARTNET_DEFAULT_PORT,
+                max_fps, refresh_interval,
+            )
+        elif node_type == NODE_TYPE_SACN:
+            node = await self._create_stock_node(
+                pyartnet.SacnNode, real_host, real_port or SACN_DEFAULT_PORT,
+                max_fps, refresh_interval, source_name="ha-artnet-led",
+            )
+        elif node_type == NODE_TYPE_KINET:
+            node = await self._create_stock_node(
+                pyartnet.KiNetNode, real_host, real_port or KINET_DEFAULT_PORT,
+                max_fps, refresh_interval,
+            )
+        elif node_type == NODE_TYPE_ARTNET_CONTROLLER:
+            node = ArtNetController(self._hass, max_fps=max_fps, refresh_every=refresh_interval)
+            node.start()
+        else:
+            raise NotImplementedError(f"Unknown client type '{node_type}'")
+
+        handle = NodeHandle(
+            key=key, node=node, owner=owner, node_type=node_type, host=host, port=port,
+        )
+        self._handles[key] = handle
+        log.info("Started %s node '%s' (owner: %s)", node_type, key, owner)
+        return handle
+
+    @staticmethod
+    async def _create_stock_node(cls, real_host, real_port, max_fps, refresh_interval, **kwargs):
+        from pyartnet.base.network import UnicastNetworkTarget
+
+        node = cls(
+            UnicastNetworkTarget.create(real_host, real_port),
+            max_fps=max_fps,
+            refresh_every=refresh_interval,
+            **kwargs,
+        )
+        await node.__aenter__()
+        if not refresh_interval:
+            await node.stop_refresh()
+        return node
+
+    async def release_owner(self, owner: str) -> None:
+        for handle in self.handles(owner):
+            await self._stop_handle(handle)
+
+    async def release_all(self) -> None:
+        for handle in list(self._handles.values()):
+            await self._stop_handle(handle)
+
+    async def _stop_handle(self, handle: NodeHandle) -> None:
+        self._handles.pop(handle.key, None)
+        try:
+            if isinstance(handle.node, ArtNetController):
+                await handle.node.stop()
+            else:
+                await handle.node.stop_refresh()
+                await handle.node.__aexit__(None, None, None)
+        except Exception:
+            log.exception("Error while stopping node '%s'", handle.key)
+        else:
+            log.info("Stopped node '%s'", handle.key)
+
+    def snapshot(self, owner: str | None = None) -> list[dict]:
+        """JSON-serializable view of running nodes, for the panel."""
+        result = []
+        for handle in self.handles(owner):
+            result.append(
+                {
+                    "key": handle.key,
+                    "owner": handle.owner,
+                    "node_type": handle.node_type,
+                    "host": handle.host,
+                    "port": handle.port,
+                    "universes": {
+                        str(nr): cfg for nr, cfg in sorted(handle.universes_cfg.items())
+                    },
+                }
+            )
+        return result

--- a/custom_components/artnet_led/store.py
+++ b/custom_components/artnet_led/store.py
@@ -1,0 +1,32 @@
+"""Persistence for the UI-edited DMX patch (.storage/artnet_led.patch)."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from custom_components.artnet_led.const import STORAGE_KEY, STORAGE_VERSION
+
+EMPTY_PATCH: dict[str, Any] = {"nodes": []}
+
+
+class _PatchStorage(Store):
+    async def _async_migrate_func(self, old_major_version, old_minor_version, old_data):
+        # Schema v1; seam for future migrations (e.g. fixture-library model).
+        return old_data
+
+
+class PatchStore:
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._store = _PatchStorage(hass, STORAGE_VERSION, STORAGE_KEY)
+
+    async def async_load(self) -> dict:
+        data = await self._store.async_load()
+        if not data:
+            return {"nodes": []}
+        data.setdefault("nodes", [])
+        return data
+
+    async def async_save(self, patch: dict) -> None:
+        await self._store.async_save(patch)

--- a/custom_components/artnet_led/strings.json
+++ b/custom_components/artnet_led/strings.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "DMX Patch",
+        "description": "Create the DMX patch. After setup, edit your nodes, universes and fixtures in the DMX Patch panel in the sidebar."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single DMX patch is supported. Edit it in the DMX Patch panel."
+    }
+  }
+}

--- a/custom_components/artnet_led/translations/en.json
+++ b/custom_components/artnet_led/translations/en.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "DMX Patch",
+        "description": "Create the DMX patch. After setup, edit your nodes, universes and fixtures in the DMX Patch panel in the sidebar."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single DMX patch is supported. Edit it in the DMX Patch panel."
+    }
+  }
+}

--- a/custom_components/artnet_led/validation.py
+++ b/custom_components/artnet_led/validation.py
@@ -1,0 +1,211 @@
+"""Validation of the UI-edited patch document, and conversion to setup config."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.const import CONF_DEVICES
+from homeassistant.const import CONF_HOST as CONF_NODE_HOST
+from homeassistant.const import CONF_NAME as CONF_DEVICE_NAME
+from homeassistant.const import CONF_PORT as CONF_NODE_PORT
+from homeassistant.const import CONF_TYPE as CONF_DEVICE_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
+
+from custom_components.artnet_led.const import (
+    CHANNEL_SIZE,
+    CONF_CHANNEL_SETUP,
+    CONF_CHANNEL_SIZE,
+    CONF_DEVICE_CHANNEL,
+    CONF_NODE_HOST_OVERRIDE,
+    CONF_NODE_MAX_FPS,
+    CONF_NODE_PORT_OVERRIDE,
+    CONF_NODE_REFRESH,
+    CONF_NODE_TYPE,
+    CONF_NODE_UNIVERSES,
+    CONF_OUTPUT_CORRECTION,
+    CONF_SEND_PARTIAL_UNIVERSE,
+    NODE_TYPE_ARTNET_CONTROLLER,
+    NODE_TYPES,
+    OWNER_YAML,
+)
+from custom_components.artnet_led.runtime import ArtNetRuntime, node_key
+
+log = logging.getLogger(__name__)
+
+# Default channel_setup per device type, mirrored from the entity class constructors
+# in light.py (DmxFixed, DmxWhite, DmxRGB, ...). Determines the logical channel width.
+DEFAULT_CHANNEL_SETUP: dict[str, Any] = {
+    "fixed": [255],
+    "binary": None,
+    "dimmer": None,
+    "color_temp": "ch",
+    "rgb": "rgb",
+    "rgbw": "rgbw",
+    "rgbww": "rgbch",
+    "xy": "dxy",
+}
+
+
+def compute_channel_width(device_type: str, channel_setup) -> int:
+    """Logical channel count of a device, matching the entity class constructors."""
+    if device_type in ("binary", "dimmer"):
+        return 1
+    setup = channel_setup or DEFAULT_CHANNEL_SETUP.get(device_type)
+    return len(setup) if setup else 1
+
+
+def compute_dmx_footprint(device: dict) -> tuple[int, int]:
+    """(first, last) DMX channel occupied by a device, inclusive."""
+    start = int(device[CONF_DEVICE_CHANNEL])
+    width = compute_channel_width(device.get(CONF_DEVICE_TYPE, "dimmer"),
+                                  device.get(CONF_CHANNEL_SETUP))
+    byte_size = CHANNEL_SIZE.get(device.get(CONF_CHANNEL_SIZE) or "8bit", (1, 1))[0]
+    return start, start + width * byte_size - 1
+
+
+def patch_node_to_setup_config(node: dict) -> dict:
+    """Convert a stored patch node into the config dict the runtime/factory expects.
+
+    Devices are run through DEVICE_SCHEMA so defaults are filled exactly like YAML.
+    """
+    from custom_components.artnet_led.light import DEVICE_SCHEMA, UNIVERSE_SCHEMA
+
+    universes: dict[int, dict] = {}
+    for universe_nr, universe in (node.get("universes") or {}).items():
+        universes[int(universe_nr)] = UNIVERSE_SCHEMA(
+            {
+                CONF_SEND_PARTIAL_UNIVERSE: universe.get(CONF_SEND_PARTIAL_UNIVERSE, True),
+                CONF_OUTPUT_CORRECTION: universe.get(CONF_OUTPUT_CORRECTION) or "linear",
+                CONF_DEVICES: [
+                    # Strip panel-only keys (id) before schema validation.
+                    DEVICE_SCHEMA({k: v for k, v in device.items()
+                                   if k != "id" and v is not None})
+                    for device in universe.get("devices", [])
+                ],
+            }
+        )
+
+    return {
+        CONF_NODE_TYPE: node.get(CONF_NODE_TYPE, "artnet-direct"),
+        CONF_NODE_HOST: node.get("host"),
+        CONF_NODE_PORT: node.get("port"),
+        CONF_NODE_HOST_OVERRIDE: node.get(CONF_NODE_HOST_OVERRIDE) or "",
+        CONF_NODE_PORT_OVERRIDE: node.get(CONF_NODE_PORT_OVERRIDE),
+        CONF_NODE_MAX_FPS: node.get(CONF_NODE_MAX_FPS) or 25,
+        CONF_NODE_REFRESH: node.get(CONF_NODE_REFRESH, 120),
+        CONF_NODE_UNIVERSES: universes,
+    }
+
+
+def validate_patch(hass: HomeAssistant, patch: dict, runtime: ArtNetRuntime) -> list[dict]:
+    """Validate a patch document. Returns a list of {path, code, message} errors."""
+    from custom_components.artnet_led.light import DEVICE_SCHEMA
+
+    errors: list[dict] = []
+
+    def error(path: str, code: str, message: str) -> None:
+        errors.append({"path": path, "code": code, "message": message})
+
+    nodes = patch.get("nodes")
+    if not isinstance(nodes, list):
+        error("nodes", "invalid_structure", "'nodes' must be a list")
+        return errors
+
+    yaml_handles = runtime.handles(OWNER_YAML)
+    yaml_keys = {h.key for h in yaml_handles}
+    yaml_names = {
+        slugify(device[CONF_DEVICE_NAME])
+        for handle in yaml_handles
+        for universe in handle.universes_cfg.values()
+        for device in universe.get(CONF_DEVICES, [])
+    }
+
+    seen_node_keys: set[str] = set()
+    seen_names: dict[str, str] = {}
+
+    for i, node in enumerate(nodes):
+        node_path = f"nodes/{i}"
+
+        node_type = node.get(CONF_NODE_TYPE)
+        if node_type not in NODE_TYPES:
+            error(f"{node_path}/node_type", "invalid_node_type",
+                  f"Node type must be one of {NODE_TYPES}")
+            continue
+
+        host = node.get("host")
+        if not host or not isinstance(host, str):
+            error(f"{node_path}/host", "missing_host", "Host is required")
+            continue
+
+        max_fps = node.get(CONF_NODE_MAX_FPS) or 25
+        if not (1 <= int(max_fps) <= 50):
+            error(f"{node_path}/max_fps", "out_of_range", "max_fps must be between 1 and 50")
+
+        refresh = node.get(CONF_NODE_REFRESH, 120)
+        if not (0 <= float(refresh) <= 9999):
+            error(f"{node_path}/refresh_every", "out_of_range",
+                  "refresh_every must be between 0 and 9999")
+
+        key = node_key(node_type, host, node.get("port"))
+        if key in seen_node_keys:
+            error(f"{node_path}/host", "duplicate_node",
+                  f"Node '{key}' is defined more than once in the patch")
+        seen_node_keys.add(key)
+
+        if key in yaml_keys:
+            error(f"{node_path}/host", "yaml_conflict",
+                  f"Node '{key}' is already configured in YAML; remove it there first "
+                  "or use a different host/port")
+
+        for universe_nr, universe in (node.get("universes") or {}).items():
+            universe_path = f"{node_path}/universes/{universe_nr}"
+            try:
+                nr = int(universe_nr)
+            except (TypeError, ValueError):
+                error(universe_path, "invalid_universe", "Universe must be a number")
+                continue
+            if not (0 <= nr <= 1024):
+                error(universe_path, "invalid_universe",
+                      "Universe must be between 0 and 1024")
+
+            occupied: list[tuple[int, int, str]] = []
+            for j, device in enumerate(universe.get("devices", [])):
+                device_path = f"{universe_path}/devices/{j}"
+
+                try:
+                    validated = DEVICE_SCHEMA(
+                        {k: v for k, v in device.items() if k != "id" and v is not None}
+                    )
+                except vol.Invalid as e:
+                    field = "/".join(str(p) for p in e.path) if e.path else ""
+                    error(f"{device_path}/{field}" if field else device_path,
+                          "invalid_device", str(e))
+                    continue
+
+                name = validated[CONF_DEVICE_NAME]
+                slug = slugify(name)
+                if slug in seen_names:
+                    error(f"{device_path}/name", "duplicate_name",
+                          f"Name '{name}' collides with '{seen_names[slug]}' "
+                          f"(both become entity light.{slug})")
+                elif slug in yaml_names:
+                    error(f"{device_path}/name", "duplicate_name",
+                          f"Name '{name}' collides with a YAML-configured light "
+                          f"(both become entity light.{slug})")
+                seen_names[slug] = name
+
+                first, last = compute_dmx_footprint(validated)
+                if last > 512:
+                    error(f"{device_path}/channel", "exceeds_universe",
+                          f"Device occupies channels {first}-{last}, beyond 512")
+                for (o_first, o_last, o_name) in occupied:
+                    if first <= o_last and last >= o_first:
+                        error(f"{device_path}/channel", "channel_overlap",
+                              f"Channels {first}-{last} of '{name}' overlap with "
+                              f"'{o_name}' ({o_first}-{o_last})")
+                        break
+                occupied.append((first, last, name))
+
+    return errors

--- a/custom_components/artnet_led/websocket_api.py
+++ b/custom_components/artnet_led/websocket_api.py
@@ -1,0 +1,171 @@
+"""WebSocket API backing the DMX patch panel."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.artnet_led.const import (
+    DATA_MONITOR,
+    DATA_STORE,
+    DOMAIN,
+    NODE_TYPE_ARTNET_CONTROLLER,
+    OWNER_YAML,
+    STORAGE_VERSION,
+)
+from custom_components.artnet_led.runtime import ArtNetRuntime
+
+log = logging.getLogger(__name__)
+
+
+def async_register_commands(hass: HomeAssistant) -> None:
+    websocket_api.async_register_command(hass, ws_patch_get)
+    websocket_api.async_register_command(hass, ws_patch_validate)
+    websocket_api.async_register_command(hass, ws_patch_save)
+    websocket_api.async_register_command(hass, ws_status_get)
+    websocket_api.async_register_command(hass, ws_entity_map_get)
+    websocket_api.async_register_command(hass, ws_dmx_subscribe)
+
+
+def _store(hass: HomeAssistant):
+    return hass.data[DOMAIN][DATA_STORE]
+
+
+def _entry(hass: HomeAssistant):
+    entries = hass.config_entries.async_entries(DOMAIN)
+    return entries[0] if entries else None
+
+
+@websocket_api.websocket_command({vol.Required("type"): "artnet_led/patch/get"})
+@websocket_api.async_response
+async def ws_patch_get(hass: HomeAssistant, connection, msg) -> None:
+    runtime = ArtNetRuntime.get(hass)
+    patch = await _store(hass).async_load()
+    connection.send_result(
+        msg["id"],
+        {
+            "schema_version": STORAGE_VERSION,
+            "patch": patch,
+            "yaml_nodes": runtime.snapshot(owner=OWNER_YAML),
+            "entry_exists": _entry(hass) is not None,
+        },
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "artnet_led/patch/validate",
+        vol.Required("patch"): dict,
+    }
+)
+@websocket_api.async_response
+async def ws_patch_validate(hass: HomeAssistant, connection, msg) -> None:
+    from custom_components.artnet_led.validation import validate_patch
+
+    runtime = ArtNetRuntime.get(hass)
+    errors = validate_patch(hass, msg["patch"], runtime)
+    connection.send_result(msg["id"], {"valid": not errors, "errors": errors})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "artnet_led/patch/save",
+        vol.Required("patch"): dict,
+    }
+)
+@websocket_api.async_response
+async def ws_patch_save(hass: HomeAssistant, connection, msg) -> None:
+    from custom_components.artnet_led.validation import validate_patch
+
+    runtime = ArtNetRuntime.get(hass)
+    patch = msg["patch"]
+
+    errors = validate_patch(hass, patch, runtime)
+    if errors:
+        connection.send_result(msg["id"], {"success": False, "errors": errors})
+        return
+
+    await _store(hass).async_save(patch)
+
+    entry = _entry(hass)
+    if entry is not None:
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+    else:
+        # First save: create the config entry, which triggers setup.
+        await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data={}
+        )
+
+    connection.send_result(msg["id"], {"success": True, "errors": []})
+
+
+@websocket_api.websocket_command({vol.Required("type"): "artnet_led/status/get"})
+@websocket_api.async_response
+async def ws_status_get(hass: HomeAssistant, connection, msg) -> None:
+    from socket import inet_ntoa
+
+    runtime = ArtNetRuntime.get(hass)
+
+    discovered = []
+    for handle in runtime.handles():
+        if handle.node_type != NODE_TYPE_ARTNET_CONTROLLER:
+            continue
+        server = handle.node.server
+        for (ip, bind_index), node in server.nodes_by_ip.items():
+            discovered.append(
+                {
+                    "ip": inet_ntoa(ip),
+                    "bind_index": bind_index,
+                    "net": node.net_switch,
+                    "sub_net": node.sub_switch,
+                    "port_addresses": [str(a) for a in sorted(node.get_addresses())],
+                    "last_seen": node.last_seen.isoformat(),
+                }
+            )
+
+    connection.send_result(
+        msg["id"],
+        {"nodes": runtime.snapshot(), "discovered": discovered},
+    )
+
+
+@websocket_api.websocket_command({vol.Required("type"): "artnet_led/entity_map/get"})
+@websocket_api.async_response
+async def ws_entity_map_get(hass: HomeAssistant, connection, msg) -> None:
+    registry = er.async_get(hass)
+    entity_map = {
+        entry.unique_id: entry.entity_id
+        for entry in registry.entities.values()
+        if entry.platform == DOMAIN
+    }
+    connection.send_result(msg["id"], {"entities": entity_map})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "artnet_led/dmx/subscribe",
+        vol.Required("node_key"): str,
+        vol.Required("universe"): int,
+    }
+)
+@websocket_api.async_response
+async def ws_dmx_subscribe(hass: HomeAssistant, connection, msg) -> None:
+    monitor = hass.data[DOMAIN].get(DATA_MONITOR)
+    if monitor is None:
+        connection.send_error(msg["id"], "not_available", "DMX monitor not initialized")
+        return
+
+    msg_id = msg["id"]
+
+    @callback
+    def forward(payload: dict) -> None:
+        connection.send_event(msg_id, payload)
+
+    unsub = monitor.subscribe(msg["node_key"], msg["universe"], forward)
+    connection.subscriptions[msg_id] = unsub
+    connection.send_result(msg_id)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = test

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield

--- a/test/test_config_entry.py
+++ b/test/test_config_entry.py
@@ -1,0 +1,150 @@
+"""Config entry lifecycle: setup from stored patch, live reload, teardown."""
+import pytest
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+# The tests drive real pyartnet nodes, which bind UDP sockets.
+pytestmark = pytest.mark.usefixtures("socket_enabled")
+
+from custom_components.artnet_led.const import (
+    DATA_STORE,
+    DOMAIN,
+    STORAGE_KEY,
+)
+
+PATCH_DOC = {
+    "nodes": [
+        {
+            "id": "node-1",
+            "node_type": "artnet-direct",
+            "host": "127.0.0.1",
+            "port": 6454,
+            "max_fps": 25,
+            "refresh_every": 0,
+            "universes": {
+                "1": {
+                    "send_partial_universe": True,
+                    "output_correction": "linear",
+                    "devices": [
+                        {
+                            "id": "dev-1",
+                            "channel": 1,
+                            "name": "ui_test_dimmer",
+                            "type": "dimmer",
+                        },
+                        {
+                            "id": "dev-2",
+                            "channel": 10,
+                            "name": "ui_test_rgb",
+                            "type": "rgb",
+                        },
+                    ],
+                }
+            },
+        }
+    ]
+}
+
+
+@pytest.fixture
+def stored_patch(hass_storage):
+    hass_storage[STORAGE_KEY] = {"version": 1, "data": PATCH_DOC}
+    return hass_storage
+
+
+async def test_entry_creates_entities_and_unloads(hass, stored_patch):
+    entry = MockConfigEntry(domain=DOMAIN, title="DMX Patch", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.ui_test_dimmer")
+    assert state is not None
+    assert hass.states.get("light.ui_test_rgb") is not None
+
+    from homeassistant.helpers import entity_registry as er
+
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get("light.ui_test_dimmer")
+    assert reg_entry is not None
+    assert reg_entry.unique_id == "dmx:127.0.0.1/1/1"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.ui_test_dimmer").state == "unavailable"
+
+
+async def test_entry_reload_preserves_unique_id(hass, stored_patch):
+    entry = MockConfigEntry(domain=DOMAIN, title="DMX Patch", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get("light.ui_test_dimmer")
+    assert reg_entry is not None
+    assert reg_entry.unique_id == "dmx:127.0.0.1/1/1"
+    assert hass.states.get("light.ui_test_dimmer").state != "unavailable"
+
+
+async def test_ws_patch_save_triggers_reload(hass, stored_patch, hass_ws_client):
+    assert await async_setup_component(hass, DOMAIN, {})
+    entry = MockConfigEntry(domain=DOMAIN, title="DMX Patch", data={})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    # Add a new fixture and save; its entity should appear without a restart.
+    import copy
+
+    new_patch = copy.deepcopy(PATCH_DOC)
+    new_patch["nodes"][0]["universes"]["1"]["devices"].append(
+        {"id": "dev-new", "channel": 20, "name": "ui_test_added_live", "type": "dimmer"}
+    )
+
+    await client.send_json(
+        {"id": 1, "type": "artnet_led/patch/save", "patch": new_patch}
+    )
+    response = await client.receive_json()
+    assert response["success"], response
+    assert response["result"]["success"] is True
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.ui_test_added_live") is not None
+    # Pre-existing entities survived the live reload.
+    assert hass.states.get("light.ui_test_dimmer").state != "unavailable"
+
+
+async def test_ws_validate_rejects_overlap(hass, hass_ws_client):
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    import copy
+
+    bad_patch = copy.deepcopy(PATCH_DOC)
+    # rgb at channel 10 occupies 10-12; place another device at 11.
+    bad_patch["nodes"][0]["universes"]["1"]["devices"].append(
+        {"id": "dev-3", "channel": 11, "name": "ui_overlapping", "type": "dimmer"}
+    )
+
+    await client.send_json(
+        {"id": 1, "type": "artnet_led/patch/validate", "patch": bad_patch}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"]["valid"] is False
+    codes = {e["code"] for e in response["result"]["errors"]}
+    assert "channel_overlap" in codes

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -1,0 +1,59 @@
+"""DmxMonitor: change-only coalesced pushes, cleanup on last unsubscribe."""
+import asyncio
+
+import pytest
+
+from custom_components.artnet_led.const import DOMAIN
+from custom_components.artnet_led.monitor import DmxMonitor
+from custom_components.artnet_led.runtime import ArtNetRuntime, NodeHandle
+
+
+class _FakeUniverse:
+    def __init__(self):
+        self._data = bytearray([0, 0, 0, 0])
+
+
+class _FakeNode:
+    def __init__(self, universe):
+        self._universe = universe
+
+    def get_universe(self, nr):
+        return self._universe
+
+
+@pytest.fixture
+def fake_universe(hass):
+    runtime = ArtNetRuntime.get(hass)
+    universe = _FakeUniverse()
+    handle = NodeHandle(
+        key="fake:1", node=_FakeNode(universe), owner="test",
+        node_type="artnet-direct", host="fake", port=None,
+    )
+    runtime._handles["fake:1"] = handle
+    return universe
+
+
+async def test_monitor_pushes_on_change_only(hass, fake_universe):
+    monitor = DmxMonitor(hass)
+    frames = []
+
+    unsub = monitor.subscribe("fake:1", 1, frames.append)
+
+    await asyncio.sleep(0.25)
+    assert len(frames) == 1  # initial snapshot, then silence while unchanged
+    assert frames[0]["values"] == [0, 0, 0, 0]
+
+    fake_universe._data[0] = 200
+    await asyncio.sleep(0.25)
+    assert len(frames) == 2
+    assert frames[1]["values"][0] == 200
+    assert frames[1]["seq"] > frames[0]["seq"]
+
+    await asyncio.sleep(0.25)
+    assert len(frames) == 2  # still no change, still no push
+
+    unsub()
+    fake_universe._data[0] = 10
+    await asyncio.sleep(0.25)
+    assert len(frames) == 2  # unsubscribed: no more pushes
+    assert not monitor._tasks  # poll task cleaned up

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,0 +1,85 @@
+"""Unit tests for patch validation and footprint math."""
+from custom_components.artnet_led.runtime import ArtNetRuntime
+from custom_components.artnet_led.validation import (
+    compute_channel_width,
+    compute_dmx_footprint,
+    validate_patch,
+)
+
+
+def test_channel_widths():
+    assert compute_channel_width("dimmer", None) == 1
+    assert compute_channel_width("binary", None) == 1
+    assert compute_channel_width("rgb", None) == 3
+    assert compute_channel_width("rgbw", None) == 4
+    assert compute_channel_width("rgbww", None) == 5
+    assert compute_channel_width("color_temp", None) == 2
+    assert compute_channel_width("xy", None) == 3
+    assert compute_channel_width("fixed", None) == 1
+    assert compute_channel_width("color_temp", "dCH") == 3
+    assert compute_channel_width("fixed", [255, 0, 128]) == 3
+
+
+def test_footprint_16bit():
+    device = {"channel": 10, "type": "rgb", "channel_size": "16bit"}
+    assert compute_dmx_footprint(device) == (10, 15)
+
+
+async def test_validate_rejects_footprint_past_512(hass):
+    runtime = ArtNetRuntime.get(hass)
+    patch = {
+        "nodes": [
+            {
+                "id": "n", "node_type": "artnet-direct", "host": "1.2.3.4",
+                "universes": {
+                    "0": {"devices": [{"id": "d", "channel": 511, "name": "x", "type": "rgb"}]}
+                },
+            }
+        ]
+    }
+    errors = validate_patch(hass, patch, runtime)
+    assert any(e["code"] == "exceeds_universe" for e in errors)
+
+
+async def test_validate_duplicate_names(hass):
+    runtime = ArtNetRuntime.get(hass)
+    patch = {
+        "nodes": [
+            {
+                "id": "n", "node_type": "artnet-direct", "host": "1.2.3.4",
+                "universes": {
+                    "0": {
+                        "devices": [
+                            {"id": "a", "channel": 1, "name": "Same Name", "type": "dimmer"},
+                            {"id": "b", "channel": 5, "name": "same_name", "type": "dimmer"},
+                        ]
+                    }
+                },
+            }
+        ]
+    }
+    errors = validate_patch(hass, patch, runtime)
+    assert any(e["code"] == "duplicate_name" for e in errors)
+
+
+async def test_validate_ok_patch(hass):
+    runtime = ArtNetRuntime.get(hass)
+    patch = {
+        "nodes": [
+            {
+                "id": "n", "node_type": "sacn", "host": "1.2.3.4", "port": None,
+                "max_fps": 30, "refresh_every": 0,
+                "universes": {
+                    "1": {
+                        "output_correction": "quadratic",
+                        "devices": [
+                            {"id": "a", "channel": 1, "name": "spot_a", "type": "rgbw",
+                             "channel_size": "16bit"},
+                            {"id": "b", "channel": 9, "name": "spot_b", "type": "dimmer"},
+                        ],
+                    }
+                },
+            }
+        ]
+    }
+    assert validate_patch(hass, patch, runtime) == []


### PR DESCRIPTION
Turn the YAML-only light platform into a config-entry integration with a visual patch editor, while keeping existing YAML configuration working:

- DMX Patch sidebar panel (Lit, bundled with esbuild): per-universe 512-channel grid, click-to-place fixtures with all device options, and live DMX value monitoring at 10 Hz
- Save & Apply persists the patch to .storage/artnet_led.patch and reloads the config entry, so changes take effect without a restart
- ArtNetRuntime owns pyartnet node lifecycle (replaces the leaky module-level NODES cache); ArtNetServer and ArtNetController gain stop() so UDP 6454 can be rebound on reload
- Shared entity factory keeps the dmx:host/universe/channel unique_id scheme so entities survive reloads and keep their registry history
- Patch validation: channel overlaps, footprints past 512, duplicate entity names, and YAML/UI node ownership conflicts
- YAML nodes appear read-only in the panel; a node can be owned by YAML or the UI patch, never both
- Tests for entry lifecycle, live reload, validation, and the monitor